### PR TITLE
Setup for dependency injection 

### DIFF
--- a/Genie4.csproj
+++ b/Genie4.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
-    <StartupObject>GenieClient.My.MyApplication</StartupObject>
+    <StartupObject>GenieClient.Program</StartupObject>
     <RootNamespace>GenieClient</RootNamespace>
     <AssemblyName>Genie</AssemblyName>
     <MyType>WindowsForms</MyType>
@@ -64,20 +64,19 @@
     <None Remove="Plugin\**" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Antlr3.Runtime, Version=3.1.3.22795, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="Antlr3.Runtime">
       <HintPath>Libs\Antlr3.Runtime.dll</HintPath>
-      <Private>False</Private>
     </Reference>
-    <Reference Include="Interfaces, Version=1.4.0.0, Culture=neutral, PublicKeyToken=44f04dde822a2be6, processorArchitecture=MSIL">
+    <Reference Include="Interfaces">
+      <HintPath>Libs\Interfaces.dll</HintPath>
+    </Reference>
+    <!--<Reference Include="Interfaces, Version=1.4.0.0, Culture=neutral, PublicKeyToken=44f04dde822a2be6, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>Libs\Interfaces.dll</HintPath>
       <Private>False</Private>
-    </Reference>
-    <Reference Include="Jint, Version=0.8.8.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    </Reference>-->
+    <Reference Include="Jint">
       <HintPath>Libs\Jint.dll</HintPath>
-      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -200,9 +199,12 @@
   <ItemGroup>
     <EmbeddedResource Include="Libs\Antlr3.Runtime.dll" />
     <EmbeddedResource Include="Libs\Interfaces.dll" />
-    <EmbeddedResource Include="Libs\Jint.dll" />
+    <EmbeddedResource Include="Libs\Jint.dll">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
     <PackageReference Include="Microsoft.VisualBasic" Version="10.3.0" />
     <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.3.261602">
       <PrivateAssets>all</PrivateAssets>

--- a/Program.cs
+++ b/Program.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using System;
+using System.Windows.Forms;
+
+namespace GenieClient
+{
+    static class Program
+    {
+        [STAThread]
+        static void Main()
+        {
+            Application.SetHighDpiMode(HighDpiMode.SystemAware);
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
+
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureServices((context, services) =>
+                {
+                    ConfigureServices(context.Configuration, services);
+                })
+                .Build();
+
+            var services = host.Services;
+            var formMain = services.GetRequiredService<FormMain>();
+
+            Application.Run(formMain);
+        }
+
+        private static void ConfigureServices(IConfiguration configuration, IServiceCollection services)
+        {
+            services.AddSingleton<FormMain>();
+
+            //Register services here. 
+            //Example... Service.AddSingleton(Interface, Service);
+        }
+    }
+}


### PR DESCRIPTION
This will redirect the startup class to program.cs and launch FormMain from there. This change will make some other classes obsolete and if all tests well we should remove them.