### PR TITLE
feat: add global var $destination to be auto-populated by automapper

### DIFF
--- a/Mapper/AutoMapper.cs
+++ b/Mapper/AutoMapper.cs
@@ -1213,6 +1213,7 @@ namespace GenieClient.Mapper
                                     if (!Information.IsNothing(n))
                                     {
                                         EchoText("#goto " + sArg, true);
+                                        set_GlobalVariable("destination", iNodeID.ToString());
                                         SendText("#parse DESTINATION FOUND");
                                         WalkToNode(n);
                                     }
@@ -1951,6 +1952,7 @@ namespace GenieClient.Mapper
 
         private void GrapForm_ClickNode(string zoneid, int nodeid)
         {
+            set_GlobalVariable("destination", nodeid.ToString());
             SendText(string.Format("#parse MAPCLICK {0} {1}", zoneid, nodeid));
         }
 

--- a/Mapper/AutoMapper.cs
+++ b/Mapper/AutoMapper.cs
@@ -1220,18 +1220,21 @@ namespace GenieClient.Mapper
                                     else
                                     {
                                         EchoText("[" + Name + "] Destination ID #" + iNodeID.ToString() + " not found - your current location is unknown.", true);
+                                        set_GlobalVariable("destination", "0");
                                         SendText("#parse DESTINATION NOT FOUND");
                                     }
                                 }
                                 else
                                 {
                                     EchoText("[" + Name + "] Destination ID \"" + sArg + "\" not found.", true);
+                                    set_GlobalVariable("destination", "0");
                                     SendText("#parse DESTINATION NOT FOUND");
                                 }
                             }
                             else
                             {
                                 EchoText("[" + Name + "] Goto - please specify a room id to travel to.", true);
+                                set_GlobalVariable("destination", "0");
                             }
 
                             break;


### PR DESCRIPTION
One shortcoming with the current implementation of automapper is that if your travel is interrupted for some reason (unexpected RT, failed climb, engagement, script error, etc) there is no easy way to auto-resume travel. You could make an alias that sets the destination manually, but that wouldn't capture automapper mouse clicks. You could also trigger off of the MAPCLICK event to get around this, but that fires for non-navigation as well. Instead, it would be much cleaner for the Automapper to set the destination id automatically.

This also can simplify logic around navigation failures because if the "$destination" == "0" then you will not be successful in moving!

My main question with this PR is how do we feel about the global variable name? It is somewhat generic and could potentially conflict with user scripts. On the other hand, I think it would be used frequently so I don't want to choose a name that's too long.