### PR TITLE
Implementing TLS via TcpClient

### DIFF
--- a/Core/Connection.cs
+++ b/Core/Connection.cs
@@ -160,7 +160,10 @@ namespace GenieClient.Genie
                 m_SocketClient = _client.Client;
                 var hostEntryList = Dns.GetHostEntry(sHostname);
                 m_IPEndPoint = new IPEndPoint(hostEntryList.AddressList.Where(i => i.AddressFamily == AddressFamily.InterNetwork).FirstOrDefault(), iPort);
-                m_SocketClient.BeginConnect(m_IPEndPoint, new AsyncCallback(ConnectCallback), _client);
+                _client.Connect(sHostname, iPort);
+                PrintText(Utility.GetTimeStamp() + " Connected to " + m_sHostname + ".");
+                Recieve(_client);
+                EventConnected?.Invoke();
             }
             catch (SocketException ex)
             {
@@ -373,6 +376,7 @@ namespace GenieClient.Genie
             buffer = new byte[MAX_PACKET_SIZE];
             CurrentAuthState = AuthState.Authenticated;
             _ = sslStream.Read(buffer, 0, buffer.Length);
+            
             sslStream.Close();
             string character_key = Encoding.Default.GetString(buffer);
             return character_key;

--- a/Core/Connection.cs
+++ b/Core/Connection.cs
@@ -141,8 +141,6 @@ namespace GenieClient.Genie
         {
             try
             {
-                // PrintText("Connecting to: " & sHostname & ":" & iPort.ToString())
-
                 m_RowBuffer.Clear(); // Reset row buffer
                 m_ParseBuffer.Clear(); // Reset parse buffer
                 if (!Information.IsNothing(m_SocketClient))
@@ -172,12 +170,10 @@ namespace GenieClient.Genie
             }
         }
 
-        public void ConnectTLS(string sHostname, int iPort)
+        public void ConnectAndAuthenticate(string sHostname, int iPort)
         {
             try
             {
-                // PrintText("Connecting to: " & sHostname & ":" & iPort.ToString())
-
                 m_RowBuffer.Clear(); // Reset row buffer
                 m_ParseBuffer.Clear(); // Reset parse buffer
                 if (!Information.IsNothing(m_SocketClient))
@@ -196,7 +192,6 @@ namespace GenieClient.Genie
                 
                 var hostEntryList = Dns.GetHostEntry(sHostname);
                 m_IPEndPoint = new IPEndPoint(hostEntryList.AddressList.Where(i => i.AddressFamily == AddressFamily.InterNetwork).FirstOrDefault(), iPort);
-                //_client.BeginConnect(sHostname, iPort, new AsyncCallback(ConnectTLSCallback), _client);
                 _client.Connect(sHostname, iPort);
                 m_oLastServerActivity = DateTime.Now;
                 try
@@ -395,56 +390,6 @@ namespace GenieClient.Genie
         public void Send(byte[] bytes)
         {
             Send(m_SocketClient, bytes);
-        }
-
-        private void ConnectCallback(IAsyncResult ar)
-        {
-            m_oLastServerActivity = DateTime.Now;
-            try
-            {
-                // Retrieve the socket from the state object
-                TcpClient s = (TcpClient)ar.AsyncState;
-                // Complete the connection
-                s.EndConnect(ar);
-                PrintText(Utility.GetTimeStamp() + " Connected to " + m_sHostname + ".");
-                Recieve(s);
-                EventConnected?.Invoke();
-            }
-            catch (SocketException ex)
-            {
-                PrintSocketError("Connect failed", ex.ErrorCode);
-                EventConnectionLost?.Invoke();
-            }
-        }
-
-        private void ConnectTLSCallback(IAsyncResult ar)
-        {
-            m_oLastServerActivity = DateTime.Now;
-            try
-            {
-                // Retrieve the socket from the state object
-                TcpClient s = (TcpClient)ar.AsyncState;
-                sslStream = new SslStream(_client.GetStream(), true, new RemoteCertificateValidationCallback(Utility.ValidateServerCertificate), null);
-                try
-                {
-                    sslStream.AuthenticateAsClient(m_sHostname);
-                }
-                catch (AuthenticationException e)
-                {
-                    PrintError("Unable to Authenticate: " + e.Message);
-                    _client.Close();
-                }
-                // Complete the connection
-                s.EndConnect(ar);
-                PrintText(Utility.GetTimeStamp() + " Connected to " + m_sHostname + ".");
-                Recieve(s);
-                EventConnected?.Invoke();
-            }
-            catch (SocketException ex)
-            {
-                PrintSocketError("Connect failed", ex.ErrorCode);
-                EventConnectionLost?.Invoke();
-            }
         }
 
         private void Disconnect(Socket ConnectedSocket, bool ExitOnDisconnect = false)

--- a/Core/Game.cs
+++ b/Core/Game.cs
@@ -3052,7 +3052,7 @@ namespace GenieClient.Genie
                         m_iConnectAttempts = 0;
                         m_bManualDisconnect = false;
                         m_oReconnectTime = default;
-                        m_oSocket.Send("<c>" + m_sConnectKey + Constants.vbLf + "<c>/FE:GENIE /VERSION:" + My.MyProject.Application.Info.Version.ToString() + " /P:WIN_XP /XML" + Constants.vbLf);    // TEMP
+                        m_oSocket.Send("<c>" + m_sConnectKey + Constants.vbLf + "<c>/FE:WIZARD /VERSION:1.0.1.22 /P:WIN_UNKNOWN /XML" + Constants.vbLf);    // TEMP
                                                                                                                                                             // m_oSocket.Send("<c>" & m_sConnectKey & vbLf & "<c>" & m_oGlobals.Config.sConnectString & vbLf)
                         string argkey = "connected";
                         string argvalue = "1";

--- a/Core/Game.cs
+++ b/Core/Game.cs
@@ -928,7 +928,7 @@ namespace GenieClient.Genie
 
         private void ParseKeyRow(string sText)
         {
-            if (sText.Length == 32 & m_sEncryptionKey.Length == 0)
+            if (sText.Length == 32 & m_sEncryptionKey.Length == 0 & !IsLich)
             {
                 m_sEncryptionKey = sText;
                 m_oSocket.Send("A" + Constants.vbTab + m_sAccountName.ToUpper() + Constants.vbTab);
@@ -2524,7 +2524,15 @@ namespace GenieClient.Genie
 
             m_sEncryptionKey = string.Empty;
             m_oConnectState = ConnectStates.ConnectingKeyServer;
-            m_oSocket.Connect(sHostName, iPort);
+            if (IsLich)
+            {
+                m_oSocket.Connect(sHostName, iPort);
+            }
+            else
+            {
+                if (sHostName == "eaccess.play.net" && iPort == 7900) iPort = 7910;
+                m_oSocket.ConnectTLS(sHostName, iPort);
+            }
         }
 
         private MatchCollection m_oMatchCollection;
@@ -3031,7 +3039,9 @@ namespace GenieClient.Genie
             {
                 case ConnectStates.ConnectingKeyServer:
                     {
-                        m_oSocket.Send("K" + System.Environment.NewLine);
+                        //m_oSocket.Send("K" + System.Environment.NewLine);
+                        m_oSocket.Authenticate(AccountName, AccountPassword);
+                        m_oSocket.Get_login_key(AccountGame, AccountGame);
                         m_oConnectState = ConnectStates.ConnectedKey;
                         break;
                     }

--- a/Core/Game.cs
+++ b/Core/Game.cs
@@ -385,7 +385,7 @@ namespace GenieClient.Genie
             //because many users will not have these predefined and defaults aren't created
             //new for old profiles, if these are null then default them
             if (!m_oGlobals.VariableList.Contains("gamehost")) m_oGlobals.VariableList.Add("gamehost", "eaccess.play.net", Globals.Variables.VariableType.Reserved);
-            if (!m_oGlobals.VariableList.Contains("gameport")) m_oGlobals.VariableList.Add("gameport", "7900", Globals.Variables.VariableType.Reserved);
+            if (!m_oGlobals.VariableList.Contains("gameport")) m_oGlobals.VariableList.Add("gameport", "7910", Globals.Variables.VariableType.Reserved);
             string argsHostName = m_oGlobals.VariableList["gamehost"].ToString();
             int.TryParse(m_oGlobals.VariableList["gameport"].ToString(), out int argiPort);
             DoConnect(argsHostName, argiPort);

--- a/Core/Game.cs
+++ b/Core/Game.cs
@@ -930,6 +930,7 @@ namespace GenieClient.Genie
         {
             if (sText.Length == 32 & m_sEncryptionKey.Length == 0 & !IsLich)
             {
+                
                 m_sEncryptionKey = sText;
                 m_oSocket.Send("A" + Constants.vbTab + m_sAccountName.ToUpper() + Constants.vbTab);
                 m_oSocket.Send(Utility.EncryptText(m_sEncryptionKey, m_sAccountPassword));
@@ -3039,10 +3040,9 @@ namespace GenieClient.Genie
             {
                 case ConnectStates.ConnectingKeyServer:
                     {
-                        //m_oSocket.Send("K" + System.Environment.NewLine);
-                        m_oSocket.Authenticate(AccountName, AccountPassword);
-                        m_oSocket.Get_login_key(AccountGame, AccountGame);
                         m_oConnectState = ConnectStates.ConnectedKey;
+                        m_oSocket.Authenticate(AccountName, AccountPassword);
+                        ParseKeyRow(m_oSocket.Get_login_key(AccountGame, AccountCharacter));
                         break;
                     }
 
@@ -3052,7 +3052,7 @@ namespace GenieClient.Genie
                         m_iConnectAttempts = 0;
                         m_bManualDisconnect = false;
                         m_oReconnectTime = default;
-                        m_oSocket.Send("<c>" + m_sConnectKey + Constants.vbLf + "<c>/FE:WIZARD /VERSION:1.0.1.22 /P:WIN_UNKNOWN /XML" + Constants.vbLf);    // TEMP
+                        m_oSocket.Send("<c>" + m_sConnectKey + Constants.vbLf + "<c>/FE:GENIE /VERSION:" + My.MyProject.Application.Info.Version.ToString() + " /P:WIN_XP /XML" + Constants.vbLf);    // TEMP
                                                                                                                                                             // m_oSocket.Send("<c>" & m_sConnectKey & vbLf & "<c>" & m_oGlobals.Config.sConnectString & vbLf)
                         string argkey = "connected";
                         string argvalue = "1";

--- a/Core/Game.cs
+++ b/Core/Game.cs
@@ -2532,7 +2532,7 @@ namespace GenieClient.Genie
             else
             {
                 if (sHostName == "eaccess.play.net" && iPort == 7900) iPort = 7910;
-                m_oSocket.ConnectTLS(sHostName, iPort);
+                m_oSocket.ConnectAndAuthenticate(sHostName, iPort);
             }
         }
 

--- a/Core/Game.cs
+++ b/Core/Game.cs
@@ -1101,7 +1101,7 @@ namespace GenieClient.Genie
                                         }
                                         else if (strRow.IndexOf("KEY=") > -1)
                                         {
-                                            m_sConnectKey = strRow.Substring(4);
+                                            m_sConnectKey = strRow.Substring(4).TrimEnd('\0');
                                         }
                                     }
 

--- a/Lists/Config.cs
+++ b/Lists/Config.cs
@@ -47,7 +47,6 @@ namespace GenieClient.Genie
         public bool bShowLinks = false;
         public string sLogDir = "Logs";
 
-        // Public sConnectString As String = "/FE:GENIE /VERSION:GENIE3 /XML"
         public string sConnectString = "FE:GENIE /VERSION:" + My.MyProject.Application.Info.Version.ToString() + " /P:WIN_XP /XML";
         public int[] iPickerColors = new int[17];
         public string RubyPath { get; set; } = @"C:\ruby4lich\bin\ruby.exe";

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // <Assembly: AssemblyVersion("1.0.*")> 
 
-[assembly: AssemblyVersion("4.0.1.5")]
-[assembly: AssemblyFileVersion("4.0.1.5")]
+[assembly: AssemblyVersion("4.0.2.0")]
+[assembly: AssemblyFileVersion("4.0.2.0")]


### PR DESCRIPTION
Authentication flow was modified to use a TcpClient in place of a Socket 

the Connection.Connect method has been updated to use a TcpClient to provide the socket, and the BeginConnect and callback have been merged into a single Connect

The new ConnectAndAuthenticate method uses the new TcpClient to validate the received server certificate and authenticate to the server as a client, and then attempts tso log in.