### PR TITLE
Parser fixes

### DIFF
--- a/Core/Command.cs
+++ b/Core/Command.cs
@@ -2837,6 +2837,7 @@ namespace GenieClient.Genie
             EchoText("parsegameonly=" + oGlobals.Config.bParseGameOnly.ToString() + System.Environment.NewLine);
             EchoText("prompt=" + oGlobals.Config.sPrompt + System.Environment.NewLine);
             EchoText("promptbreak=" + oGlobals.Config.PromptBreak + System.Environment.NewLine);
+            EchoText("promptforce=" + oGlobals.Config.PromptForce + System.Environment.NewLine);
             EchoText("condensed=" + oGlobals.Config.Condensed + System.Environment.NewLine);
             EchoText("reconnect=" + oGlobals.Config.bReconnect.ToString() + System.Environment.NewLine);
             EchoText("roundtimeoffset=" + oGlobals.Config.dRTOffset + System.Environment.NewLine);

--- a/Core/Command.cs
+++ b/Core/Command.cs
@@ -2836,6 +2836,8 @@ namespace GenieClient.Genie
             EchoText("mycommandchar=" + oGlobals.Config.cMyCommandChar.ToString() + System.Environment.NewLine);
             EchoText("parsegameonly=" + oGlobals.Config.bParseGameOnly.ToString() + System.Environment.NewLine);
             EchoText("prompt=" + oGlobals.Config.sPrompt + System.Environment.NewLine);
+            EchoText("promptbreak=" + oGlobals.Config.PromptBreak + System.Environment.NewLine);
+            EchoText("condensed=" + oGlobals.Config.Condensed + System.Environment.NewLine);
             EchoText("reconnect=" + oGlobals.Config.bReconnect.ToString() + System.Environment.NewLine);
             EchoText("roundtimeoffset=" + oGlobals.Config.dRTOffset + System.Environment.NewLine);
             EchoText("showlinks=" + oGlobals.Config.bShowLinks.ToString() + System.Environment.NewLine);

--- a/Core/Game.cs
+++ b/Core/Game.cs
@@ -2040,7 +2040,7 @@ namespace GenieClient.Genie
                     case "prompt":
                         {
                             string strBuffer = GetTextFromXML(oXmlNode);
-                            if (m_bStatusPromptEnabled == false)
+                            if (m_bStatusPromptEnabled)
                             {
                                 if ((strBuffer ?? "") != ">")
                                 {
@@ -2178,18 +2178,17 @@ namespace GenieClient.Genie
                                     string argvalue18 = "0";
                                     m_oGlobals.VariableList.Add(argkey43, argvalue18, Globals.Variables.VariableType.Reserved);
                                 }
-
                                 string argsVariable40 = "$roundtime";
                                 VariableChanged(argsVariable40);
-                                if (m_oGlobals.Config.sPrompt.Length > 0)
+
+                                if (m_oGlobals.Config.sPrompt.Length > 0 && !m_bLastRowWasPrompt)
                                 {
-                                    strBuffer = strBuffer.Replace(">", "");
+                                    strBuffer = strBuffer.Replace(m_oGlobals.Config.sPrompt.Trim(), "");
                                     strBuffer += m_oGlobals.Config.sPrompt;
                                     bool argbIsPrompt = true;
                                     WindowTarget argoWindowTarget = 0;
 
                                     PrintTextWithParse(strBuffer, argbIsPrompt, oWindowTarget: argoWindowTarget);
-
                                 }
 
                                 string argkey44 = "prompt";
@@ -2892,20 +2891,19 @@ namespace GenieClient.Genie
             {
                 if (text.Trim().Length == 0)
                 {
-                    if (m_bLastRowWasBlank == true || m_bLastRowWasPrompt == true)
+                    if (m_bLastRowWasBlank == true)
                     {
                         return;
                     }
-
                     m_bLastRowWasBlank = true;
                 }
                 else if (Regex.IsMatch(text, @"^.*\" + m_oGlobals.Config.sPrompt + "?$"))
                 {
+                    m_bLastRowWasPrompt = true;
                     if (m_bLastRowWasBlank)
                     {
                         return;
                     }
-                    m_bLastRowWasPrompt = true;
                 }
                 else
                 {

--- a/Core/Game.cs
+++ b/Core/Game.cs
@@ -521,6 +521,7 @@ namespace GenieClient.Genie
             string sTextBuffer = string.Empty;
             char cPreviousChar = Conversions.ToChar("");
             bool bCombatRow = false;
+            bool bPromptRow = false;
 
             // Fix for DR html encoding problems
             if (sText.StartsWith("< "))
@@ -582,6 +583,13 @@ namespace GenieClient.Genie
                                 {
                                     PrintTextWithParse(sTextBuffer, bIsPrompt: false, oWindowTarget: WindowTarget.Unknown);
                                     sTextBuffer = string.Empty;
+                                }
+
+                                if (buffer.EndsWith("</prompt>"))
+                                {
+                                    XmlDocument doc = new XmlDocument();
+                                    doc.LoadXml(buffer);
+                                    CreatePrompt(doc.DocumentElement);
                                 }
 
                                 m_oXMLBuffer.Clear();
@@ -731,8 +739,9 @@ namespace GenieClient.Genie
                     m_bBold = false;
                 }
 
-                if (m_oGlobals.Config.PromptForce && m_oTargetWindow == WindowTarget.Main)
+                if (bPromptRow && m_oGlobals.Config.PromptForce && m_oTargetWindow == WindowTarget.Main)
                 {
+                    bPromptRow = false;
                     PrintTextWithParse(m_oGlobals.Config.sPrompt, true, 0);
                 }
             }
@@ -2044,164 +2053,7 @@ namespace GenieClient.Genie
                         }
                     case "prompt":
                         {
-                            string strBuffer = GetTextFromXML(oXmlNode);
-                            if (m_bStatusPromptEnabled)
-                            {
-                                if ((strBuffer ?? "") != ">")
-                                {
-                                    m_bStatusPromptEnabled = true;
-
-                                    // Fix for Joined and Bleeding
-                                    if (strBuffer.Contains("J") == false)
-                                    {
-                                        if (Conversions.ToBoolean(Operators.ConditionalCompareObjectEqual(m_oGlobals.VariableList["joined"], "1", false)))
-                                        {
-                                            string argkey37 = "joined";
-                                            string argvalue13 = "0";
-                                            m_oGlobals.VariableList.Add(argkey37, argvalue13, Globals.Variables.VariableType.Reserved);
-                                            string argsVariable35 = "$joined";
-                                            VariableChanged(argsVariable35);
-                                        }
-                                    }
-
-                                    if (strBuffer.Contains("!") == false)
-                                    {
-                                        if (Conversions.ToBoolean(Operators.ConditionalCompareObjectEqual(m_oGlobals.VariableList["bleeding"], "1", false)))
-                                        {
-                                            string argkey38 = "bleeding";
-                                            string argvalue14 = "0";
-                                            m_oGlobals.VariableList.Add(argkey38, argvalue14, Globals.Variables.VariableType.Reserved);
-                                            string argsVariable36 = "$bleeding";
-                                            VariableChanged(argsVariable36);
-                                        }
-                                    }
-                                }
-                                else if (Conversions.ToBoolean(Operators.ConditionalCompareObjectEqual(m_oIndicatorHash[Indicator.Dead], true, false)))
-                                {
-                                    strBuffer += "DEAD";
-                                }
-                                else
-                                {
-                                    if (Conversions.ToBoolean(Operators.ConditionalCompareObjectEqual(m_oIndicatorHash[Indicator.Kneeling], true, false)))
-                                    {
-                                        strBuffer += "K";
-                                    }
-
-                                    if (Conversions.ToBoolean(Operators.ConditionalCompareObjectEqual(m_oIndicatorHash[Indicator.Sitting], true, false)))
-                                    {
-                                        strBuffer += "s";
-                                    }
-
-                                    if (Conversions.ToBoolean(Operators.ConditionalCompareObjectEqual(m_oIndicatorHash[Indicator.Prone], true, false)))
-                                    {
-                                        strBuffer += "P";
-                                    }
-
-                                    if (Conversions.ToBoolean(Operators.ConditionalCompareObjectEqual(m_oIndicatorHash[Indicator.Stunned], true, false)))
-                                    {
-                                        strBuffer += "S";
-                                    }
-
-                                    if (Conversions.ToBoolean(Operators.ConditionalCompareObjectEqual(m_oIndicatorHash[Indicator.Hidden], true, false)))
-                                    {
-                                        strBuffer += "H";
-                                    }
-
-                                    if (Conversions.ToBoolean(Operators.ConditionalCompareObjectEqual(m_oIndicatorHash[Indicator.Invisible], true, false)))
-                                    {
-                                        strBuffer += "I";
-                                    }
-
-                                    if (Conversions.ToBoolean(Operators.ConditionalCompareObjectEqual(m_oIndicatorHash[Indicator.Webbed], true, false)))
-                                    {
-                                        strBuffer += "W";
-                                    }
-
-                                    if (Conversions.ToBoolean(Operators.ConditionalCompareObjectEqual(m_oIndicatorHash[Indicator.Bleeding], true, false)))
-                                    {
-                                        strBuffer += "!";
-                                    }
-
-                                    if (Conversions.ToBoolean(Operators.ConditionalCompareObjectEqual(m_oIndicatorHash[Indicator.Joined], true, false)))
-                                    {
-                                        strBuffer += "J";
-                                    }
-                                }
-                            }
-                            else
-                            {
-                                // Fix for Joined and Bleeding
-                                if (strBuffer.Contains("J") == false)
-                                {
-                                    if (Conversions.ToBoolean(Operators.ConditionalCompareObjectEqual(m_oGlobals.VariableList["joined"], "1", false)))
-                                    {
-                                        string argkey39 = "joined";
-                                        string argvalue15 = "0";
-                                        m_oGlobals.VariableList.Add(argkey39, argvalue15, Globals.Variables.VariableType.Reserved);
-                                        string argsVariable37 = "$joined";
-                                        VariableChanged(argsVariable37);
-                                    }
-                                }
-
-                                if (strBuffer.Contains("!") == false)
-                                {
-                                    if (Conversions.ToBoolean(Operators.ConditionalCompareObjectEqual(m_oGlobals.VariableList["bleeding"], "1", false)))
-                                    {
-                                        string argkey40 = "bleeding";
-                                        string argvalue16 = "0";
-                                        m_oGlobals.VariableList.Add(argkey40, argvalue16, Globals.Variables.VariableType.Reserved);
-                                        string argsVariable38 = "$bleeding";
-                                        VariableChanged(argsVariable38);
-                                    }
-                                }
-                            }
-
-                            // Dim strBuffer As String = String.Empty
-
-                            string argstrAttributeName25 = "time";
-                            if (int.TryParse(GetAttributeData(oXmlNode, argstrAttributeName25), out m_iGameTime))
-                            {
-                                string argkey41 = "gametime";
-                                string argvalue17 = m_iGameTime.ToString();
-                                m_oGlobals.VariableList.Add(argkey41, argvalue17, Globals.Variables.VariableType.Reserved);
-                                string argsVariable39 = "$gametime";
-                                VariableChanged(argsVariable39);
-                                int rt = m_iRoundTime - m_iGameTime;
-                                if (rt > 0)
-                                {
-                                    SetRoundTime(rt);
-                                    if (m_bStatusPromptEnabled == false)
-                                        strBuffer += "R";
-                                    rt += Convert.ToInt32(m_oGlobals.Config.dRTOffset);
-                                    var rtString = rt.ToString();
-                                    string argkey42 = "roundtime";
-                                    m_oGlobals.VariableList.Add(argkey42, rtString, Globals.Variables.VariableType.Reserved);
-                                }
-                                else
-                                {
-                                    string argkey43 = "roundtime";
-                                    string argvalue18 = "0";
-                                    m_oGlobals.VariableList.Add(argkey43, argvalue18, Globals.Variables.VariableType.Reserved);
-                                }
-                                string argsVariable40 = "$roundtime";
-                                VariableChanged(argsVariable40);
-
-                                if (m_oGlobals.Config.sPrompt.Length > 0 && !m_bLastRowWasPrompt)
-                                {
-                                    strBuffer = strBuffer.Replace(m_oGlobals.Config.sPrompt.Trim(), "");
-                                    strBuffer += m_oGlobals.Config.sPrompt;
-                                    bool argbIsPrompt = true;
-                                    WindowTarget argoWindowTarget = 0;
-
-                                    PrintTextWithParse(strBuffer, argbIsPrompt, oWindowTarget: argoWindowTarget);
-                                }
-
-                                string argkey44 = "prompt";
-                                m_oGlobals.VariableList.Add(argkey44, strBuffer, Globals.Variables.VariableType.Reserved);
-                                string argsVariable41 = "$prompt";
-                                VariableChanged(argsVariable41);
-                                EventTriggerPrompt?.Invoke();
-                            }
+                            CreatePrompt(oXmlNode);
 
                             break;
                         }
@@ -2419,6 +2271,168 @@ namespace GenieClient.Genie
             }
 
             return sReturn;
+        }
+
+        public void CreatePrompt(XmlNode oXmlNode)
+        {
+            string strBuffer = GetTextFromXML(oXmlNode);
+            if (m_bStatusPromptEnabled)
+            {
+                if ((strBuffer ?? "") != ">")
+                {
+                    m_bStatusPromptEnabled = true;
+
+                    // Fix for Joined and Bleeding
+                    if (strBuffer.Contains("J") == false)
+                    {
+                        if (Conversions.ToBoolean(Operators.ConditionalCompareObjectEqual(m_oGlobals.VariableList["joined"], "1", false)))
+                        {
+                            string argkey37 = "joined";
+                            string argvalue13 = "0";
+                            m_oGlobals.VariableList.Add(argkey37, argvalue13, Globals.Variables.VariableType.Reserved);
+                            string argsVariable35 = "$joined";
+                            VariableChanged(argsVariable35);
+                        }
+                    }
+
+                    if (strBuffer.Contains("!") == false)
+                    {
+                        if (Conversions.ToBoolean(Operators.ConditionalCompareObjectEqual(m_oGlobals.VariableList["bleeding"], "1", false)))
+                        {
+                            string argkey38 = "bleeding";
+                            string argvalue14 = "0";
+                            m_oGlobals.VariableList.Add(argkey38, argvalue14, Globals.Variables.VariableType.Reserved);
+                            string argsVariable36 = "$bleeding";
+                            VariableChanged(argsVariable36);
+                        }
+                    }
+                }
+                else if (Conversions.ToBoolean(Operators.ConditionalCompareObjectEqual(m_oIndicatorHash[Indicator.Dead], true, false)))
+                {
+                    strBuffer += "DEAD";
+                }
+                else
+                {
+                    if (Conversions.ToBoolean(Operators.ConditionalCompareObjectEqual(m_oIndicatorHash[Indicator.Kneeling], true, false)))
+                    {
+                        strBuffer += "K";
+                    }
+
+                    if (Conversions.ToBoolean(Operators.ConditionalCompareObjectEqual(m_oIndicatorHash[Indicator.Sitting], true, false)))
+                    {
+                        strBuffer += "s";
+                    }
+
+                    if (Conversions.ToBoolean(Operators.ConditionalCompareObjectEqual(m_oIndicatorHash[Indicator.Prone], true, false)))
+                    {
+                        strBuffer += "P";
+                    }
+
+                    if (Conversions.ToBoolean(Operators.ConditionalCompareObjectEqual(m_oIndicatorHash[Indicator.Stunned], true, false)))
+                    {
+                        strBuffer += "S";
+                    }
+
+                    if (Conversions.ToBoolean(Operators.ConditionalCompareObjectEqual(m_oIndicatorHash[Indicator.Hidden], true, false)))
+                    {
+                        strBuffer += "H";
+                    }
+
+                    if (Conversions.ToBoolean(Operators.ConditionalCompareObjectEqual(m_oIndicatorHash[Indicator.Invisible], true, false)))
+                    {
+                        strBuffer += "I";
+                    }
+
+                    if (Conversions.ToBoolean(Operators.ConditionalCompareObjectEqual(m_oIndicatorHash[Indicator.Webbed], true, false)))
+                    {
+                        strBuffer += "W";
+                    }
+
+                    if (Conversions.ToBoolean(Operators.ConditionalCompareObjectEqual(m_oIndicatorHash[Indicator.Bleeding], true, false)))
+                    {
+                        strBuffer += "!";
+                    }
+
+                    if (Conversions.ToBoolean(Operators.ConditionalCompareObjectEqual(m_oIndicatorHash[Indicator.Joined], true, false)))
+                    {
+                        strBuffer += "J";
+                    }
+                }
+            }
+            else
+            {
+                // Fix for Joined and Bleeding
+                if (strBuffer.Contains("J") == false)
+                {
+                    if (Conversions.ToBoolean(Operators.ConditionalCompareObjectEqual(m_oGlobals.VariableList["joined"], "1", false)))
+                    {
+                        string argkey39 = "joined";
+                        string argvalue15 = "0";
+                        m_oGlobals.VariableList.Add(argkey39, argvalue15, Globals.Variables.VariableType.Reserved);
+                        string argsVariable37 = "$joined";
+                        VariableChanged(argsVariable37);
+                    }
+                }
+
+                if (strBuffer.Contains("!") == false)
+                {
+                    if (Conversions.ToBoolean(Operators.ConditionalCompareObjectEqual(m_oGlobals.VariableList["bleeding"], "1", false)))
+                    {
+                        string argkey40 = "bleeding";
+                        string argvalue16 = "0";
+                        m_oGlobals.VariableList.Add(argkey40, argvalue16, Globals.Variables.VariableType.Reserved);
+                        string argsVariable38 = "$bleeding";
+                        VariableChanged(argsVariable38);
+                    }
+                }
+            }
+
+            // Dim strBuffer As String = String.Empty
+
+            string argstrAttributeName25 = "time";
+            if (int.TryParse(GetAttributeData(oXmlNode, argstrAttributeName25), out m_iGameTime))
+            {
+                string argkey41 = "gametime";
+                string argvalue17 = m_iGameTime.ToString();
+                m_oGlobals.VariableList.Add(argkey41, argvalue17, Globals.Variables.VariableType.Reserved);
+                string argsVariable39 = "$gametime";
+                VariableChanged(argsVariable39);
+                int rt = m_iRoundTime - m_iGameTime;
+                if (rt > 0)
+                {
+                    SetRoundTime(rt);
+                    if (m_bStatusPromptEnabled == false)
+                        strBuffer += "R";
+                    rt += Convert.ToInt32(m_oGlobals.Config.dRTOffset);
+                    var rtString = rt.ToString();
+                    string argkey42 = "roundtime";
+                    m_oGlobals.VariableList.Add(argkey42, rtString, Globals.Variables.VariableType.Reserved);
+                }
+                else
+                {
+                    string argkey43 = "roundtime";
+                    string argvalue18 = "0";
+                    m_oGlobals.VariableList.Add(argkey43, argvalue18, Globals.Variables.VariableType.Reserved);
+                }
+                string argsVariable40 = "$roundtime";
+                VariableChanged(argsVariable40);
+
+                if (m_oGlobals.Config.sPrompt.Length > 0 && !m_bLastRowWasPrompt)
+                {
+                    strBuffer = strBuffer.Replace(m_oGlobals.Config.sPrompt.Trim(), "");
+                    strBuffer += m_oGlobals.Config.sPrompt;
+                    bool argbIsPrompt = true;
+                    WindowTarget argoWindowTarget = 0;
+
+                    PrintTextWithParse(strBuffer, argbIsPrompt, oWindowTarget: argoWindowTarget);
+                }
+
+                string argkey44 = "prompt";
+                m_oGlobals.VariableList.Add(argkey44, strBuffer, Globals.Variables.VariableType.Reserved);
+                string argsVariable41 = "$prompt";
+                VariableChanged(argsVariable41);
+                EventTriggerPrompt?.Invoke();
+            }
         }
 
         public void ResetIndicators()
@@ -2902,9 +2916,9 @@ namespace GenieClient.Genie
                     }
                     m_bLastRowWasBlank = true;
                 }
-                else if (Regex.IsMatch(text, @"^.*\" + m_oGlobals.Config.sPrompt + "?$"))
+                else if (Regex.IsMatch(text, @"^.*\" + m_oGlobals.Config.sPrompt + "?$") && !m_oGlobals.Config.PromptForce)
                 {
-                    m_bLastRowWasPrompt = true;
+                    //m_bLastRowWasPrompt = true;
                     if (m_bLastRowWasBlank)
                     {
                         return;

--- a/Core/Game.cs
+++ b/Core/Game.cs
@@ -730,6 +730,11 @@ namespace GenieClient.Genie
                 {
                     m_bBold = false;
                 }
+
+                if (m_oGlobals.Config.PromptForce && m_oTargetWindow == WindowTarget.Main)
+                {
+                    PrintTextWithParse(m_oGlobals.Config.sPrompt, true, 0);
+                }
             }
         }
 

--- a/Core/Game.cs
+++ b/Core/Game.cs
@@ -578,9 +578,8 @@ namespace GenieClient.Genie
                                 string sTmp = ProcessXML(buffer);
                                 sTextBuffer += sTmp;
 
-                                if (buffer.EndsWith("</preset>") && m_bPresetRoomOutput)
+                                if (buffer.EndsWith("</preset>"))
                                 {
-                                    m_bPresetRoomOutput = false;
                                     PrintTextWithParse(sTextBuffer, bIsPrompt: false, oWindowTarget: WindowTarget.Unknown);
                                     sTextBuffer = string.Empty;
                                 }
@@ -1158,7 +1157,6 @@ namespace GenieClient.Genie
         private bool m_bPresetSpeechOutput = false;
         private bool m_bPresetWhisperOutput = false;
         private bool m_bPresetThoughtOutput = false;
-        private bool m_bPresetRoomOutput = false;
         private bool m_bStatusPromptEnabled = false;
 
         private string ProcessXMLNodeElement(XmlNode oXmlNode)
@@ -1539,7 +1537,6 @@ namespace GenieClient.Genie
 
                                 case "roomDesc":
                                     {
-                                        m_bPresetRoomOutput = true;
                                         m_sStyle = GetAttributeData(oXmlNode, "id");
                                         sReturn += GetTextFromXML(oXmlNode);
                                         break;
@@ -2615,32 +2612,17 @@ namespace GenieClient.Genie
 
                 if (m_bPresetSpeechOutput == true)
                 {
-                    if (sText.Contains(", \""))
-                    {
-                        color = m_oGlobals.PresetList["speech"].FgColor;
-                        bgcolor = m_oGlobals.PresetList["speech"].BgColor;
-
-                        // Log Window
-                        // If m_oTargetWindow = WindowTarget.Other Then
-                        // PrintTextToWindow(sText, color, bgcolor, WindowTarget.Log)
-                        // End If
-                    }
+                    color = m_oGlobals.PresetList["speech"].FgColor;
+                    bgcolor = m_oGlobals.PresetList["speech"].BgColor;
 
                     m_bPresetSpeechOutput = false;
                 }
 
                 if (m_bPresetWhisperOutput == true)
                 {
-                    if (sText.Contains(", \""))
-                    {
-                        color = m_oGlobals.PresetList["whispers"].FgColor;
-                        bgcolor = m_oGlobals.PresetList["whispers"].BgColor;
-
-                        // Log Window
-                        // If m_oTargetWindow = WindowTarget.Other Then
-                        // PrintTextToWindow(sText, color, bgcolor, WindowTarget.Log)
-                        // End If
-                    }
+                    
+                    color = m_oGlobals.PresetList["whispers"].FgColor;
+                    bgcolor = m_oGlobals.PresetList["whispers"].BgColor;
 
                     m_bPresetWhisperOutput = false;
                 }

--- a/Forms/Components/ComponentRichTextBox.cs
+++ b/Forms/Components/ComponentRichTextBox.cs
@@ -190,7 +190,7 @@ namespace GenieClient
 
         private string GetTimeString(string sText)
         {
-            if (m_bTimeStamp == true)
+            if (m_bTimeStamp && !m_bPendingNewLine)
             {
                 if (sText.Trim().Length > 0)
                 {
@@ -424,6 +424,7 @@ namespace GenieClient
                                         for (int I = 1, loopTo = oMatch.Groups.Count - 1; I <= loopTo; I++)
                                         {
                                             int iDiff = sLine.Length - sLine.TrimStart(Conversions.ToChar(Constants.vbCr)).Length; // RichText does not add both cr+lf
+                                            
                                             m_oRichTextBuffer.SelectionStart = iStart + oMatch.Groups[I].Index + iDiff;
                                             m_oRichTextBuffer.SelectionLength = oMatch.Groups[I].Length;
                                             if (oHighlight.FgColor != Color.Transparent & oHighlight.FgColor != m_oEmptyColor)

--- a/Forms/Components/ComponentRichTextBox.cs
+++ b/Forms/Components/ComponentRichTextBox.cs
@@ -430,10 +430,18 @@ namespace GenieClient
                                             {
                                                 m_oRichTextBuffer.SelectionColor = oHighlight.FgColor;
                                             }
+                                            else
+                                            {
+                                                m_oRichTextBuffer.SelectionColor = m_oRichTextBuffer.ForeColor;
+                                            }
 
                                             if (oHighlight.BgColor != Color.Transparent & oHighlight.FgColor != m_oEmptyColor)
                                             {
                                                 m_oRichTextBuffer.SelectionBackColor = oHighlight.BgColor;
+                                            }
+                                            else
+                                            {
+                                                m_oRichTextBuffer.SelectionBackColor = m_oRichTextBuffer.BackColor;
                                             }
                                         }
                                     }
@@ -445,10 +453,18 @@ namespace GenieClient
                                         {
                                             m_oRichTextBuffer.SelectionColor = oHighlight.FgColor;
                                         }
+                                        else
+                                        {
+                                            m_oRichTextBuffer.SelectionColor = m_oRichTextBuffer.ForeColor;
+                                        }
 
                                         if (oHighlight.BgColor != Color.Transparent & oHighlight.FgColor != m_oEmptyColor)
                                         {
                                             m_oRichTextBuffer.SelectionBackColor = oHighlight.BgColor;
+                                        }
+                                        else
+                                        {
+                                            m_oRichTextBuffer.SelectionBackColor = m_oRichTextBuffer.BackColor;
                                         }
                                     }
                                 }
@@ -500,10 +516,18 @@ namespace GenieClient
                         {
                             m_oRichTextBuffer.SelectionColor = oHighlightString.FgColor;
                         }
+                        else
+                        {
+                            m_oRichTextBuffer.SelectionColor = m_oRichTextBuffer.ForeColor;
+                        }
 
                         if (oHighlightString.BgColor != Color.Transparent & oHighlightString.FgColor != m_oEmptyColor)
                         {
                             m_oRichTextBuffer.SelectionBackColor = oHighlightString.BgColor;
+                        }
+                        else
+                        {
+                            m_oRichTextBuffer.SelectionBackColor = m_oRichTextBuffer.BackColor;
                         }
 
                         if (Conversions.ToBoolean(oHighlightString.SoundFile.Length > 0 && m_oParentForm.Globals.Config.bPlaySounds))
@@ -548,16 +572,24 @@ namespace GenieClient
                         {
                             m_oRichTextBuffer.SelectionColor = oName.FgColor;
                         }
+                        else
+                        {
+                            m_oRichTextBuffer.SelectionColor = m_oRichTextBuffer.ForeColor;
+                        }
 
                         if (oName.BgColor != Color.Transparent & oName.FgColor != m_oEmptyColor)
                         {
                             m_oRichTextBuffer.SelectionBackColor = oName.BgColor;
                         }
+                        else
+                        {
+                            m_oRichTextBuffer.SelectionBackColor = m_oRichTextBuffer.BackColor;
+                        }
                     }
                 }
             }
 
-            if (m_oRichTextBuffer.Text.Contains("You also see"))
+            if (m_oRichTextBuffer.Text.Trim().StartsWith("You also see"))
             {
                 if (!Information.IsNothing(m_oParentForm.Globals.MonsterListRegEx))
                 {
@@ -570,10 +602,18 @@ namespace GenieClient
                         {
                             m_oRichTextBuffer.SelectionColor = (Color)m_oParentForm.Globals.PresetList["creatures"].FgColor;
                         }
+                        else
+                        {
+                            m_oRichTextBuffer.SelectionColor = m_oRichTextBuffer.ForeColor;
+                        }
 
                         if (!Operators.ConditionalCompareObjectEqual(m_oParentForm.Globals.PresetList["creatures"].BgColor, Color.Transparent, false))
                         {
                             m_oRichTextBuffer.SelectionBackColor = (Color)m_oParentForm.Globals.PresetList["creatures"].BgColor;
+                        }
+                        else
+                        {
+                            m_oRichTextBuffer.SelectionBackColor = m_oRichTextBuffer.BackColor;
                         }
                     }
                 }

--- a/Forms/Components/ComponentRichTextBox.cs
+++ b/Forms/Components/ComponentRichTextBox.cs
@@ -589,7 +589,7 @@ namespace GenieClient
                 }
             }
 
-            if (m_oRichTextBuffer.Text.Trim().StartsWith("You also see"))
+            if (m_oRichTextBuffer.Text.Contains("\nYou also see"))
             {
                 if (!Information.IsNothing(m_oParentForm.Globals.MonsterListRegEx))
                 {

--- a/Forms/DialogConnect.Designer.cs
+++ b/Forms/DialogConnect.Designer.cs
@@ -133,7 +133,7 @@ namespace GenieClient
             // ComboBoxGame
             // 
             _ComboBoxGame.FormattingEnabled = true;
-            _ComboBoxGame.Items.AddRange(new object[] { "DR", "DRX", "DRF", "GS3", "GSX", "MO", "HX" });
+            _ComboBoxGame.Items.AddRange(new object[] { "DR", "DRX", "DRF", "DRT", "GS3", "GSX", "GST", "GSF" });
             _ComboBoxGame.Location = new Point(183, 71);
             _ComboBoxGame.Name = "ComboBoxGame";
             _ComboBoxGame.Size = new Size(165, 21);

--- a/Forms/FormMain.cs
+++ b/Forms/FormMain.cs
@@ -134,14 +134,14 @@ namespace GenieClient
             {
                 if (Updater.ClientIsCurrent)
                 {
-                    AddText("You are running the latest version of Genie.", m_oGlobals.PresetList["scriptecho"].FgColor, m_oGlobals.PresetList["scriptecho"].BgColor, Genie.Game.WindowTarget.Main);
+                    AddText("You are running the latest version of Genie.\r\n", m_oGlobals.PresetList["scriptecho"].FgColor, m_oGlobals.PresetList["scriptecho"].BgColor, Genie.Game.WindowTarget.Main);
                 }
                 else
                 {
-                    AddText("An Update is Available.", m_oGlobals.PresetList["scriptecho"].FgColor, m_oGlobals.PresetList["scriptecho"].BgColor, Genie.Game.WindowTarget.Main);
+                    AddText("An Update is Available.\r\n", m_oGlobals.PresetList["scriptecho"].FgColor, m_oGlobals.PresetList["scriptecho"].BgColor, Genie.Game.WindowTarget.Main);
                     if (m_oGlobals.Config.AutoUpdate)
                     {
-                        AddText("AutoUpdate is Enabled. Exiting and launching Updater.", m_oGlobals.PresetList["scriptecho"].FgColor, m_oGlobals.PresetList["scriptecho"].BgColor, Genie.Game.WindowTarget.Main);
+                        AddText("AutoUpdate is Enabled. Exiting and launching Updater.\r\n", m_oGlobals.PresetList["scriptecho"].FgColor, m_oGlobals.PresetList["scriptecho"].BgColor, Genie.Game.WindowTarget.Main);
                         Updater.RunUpdate();
                         System.Windows.Forms.Application.Exit();
                     }

--- a/Forms/FormMain.cs
+++ b/Forms/FormMain.cs
@@ -4518,6 +4518,7 @@ namespace GenieClient
 
         private void AddText(string sText, Color oColor, Color oBgColor, FormSkin oTargetWindow, bool bNoCache = true, bool bMono = false, bool bPrompt = false, bool bInput = false)
         {
+            if (sText == "\r\n" && m_oGlobals.Config.Condensed) return;
             bPrompt = false;
 
             if (IsDisposed)
@@ -4547,13 +4548,12 @@ namespace GenieClient
                     {
                         if (!bInput)
                         {
-                            if (sText.StartsWith(System.Environment.NewLine) == false)
+                            if (sText.StartsWith(System.Environment.NewLine) == false && m_oGlobals.Config.PromptBreak)
                             {
                                 sText = System.Environment.NewLine + sText;
                             }
                         }
-
-                        m_oGame.LastRowWasPrompt = false;
+                        
                     }
                 }
             }

--- a/Forms/FormMain.cs
+++ b/Forms/FormMain.cs
@@ -4519,7 +4519,6 @@ namespace GenieClient
         private void AddText(string sText, Color oColor, Color oBgColor, FormSkin oTargetWindow, bool bNoCache = true, bool bMono = false, bool bPrompt = false, bool bInput = false)
         {
             if (sText == "\r\n" && m_oGlobals.Config.Condensed) return;
-            bPrompt = false;
 
             if (IsDisposed)
             {
@@ -4535,17 +4534,13 @@ namespace GenieClient
             {
                 if (bPrompt == true)
                 {
-                    if (m_oGame.LastRowWasPrompt)
-                    {
-                        return;
-                    }
-
                     m_oGame.LastRowWasPrompt = true;
                 }
                 else if (sText.Trim().Length > 0)
                 {
                     if (m_oGame.LastRowWasPrompt == true)
                     {
+                        m_oGame.LastRowWasPrompt = false;
                         if (!bInput)
                         {
                             if (sText.StartsWith(System.Environment.NewLine) == false && m_oGlobals.Config.PromptBreak)
@@ -4553,7 +4548,6 @@ namespace GenieClient
                                 sText = System.Environment.NewLine + sText;
                             }
                         }
-                        
                     }
                 }
             }

--- a/Lists/Config.cs
+++ b/Lists/Config.cs
@@ -350,6 +350,7 @@ namespace GenieClient.Genie
                 oStreamWriter.WriteLine("#config {maxrowbuffer} {" + iBufferLineSize + "}");
                 oStreamWriter.WriteLine("#config {spelltimer} {" + bShowSpellTimer + "}");
                 oStreamWriter.WriteLine("#config {autolog} {" + bAutoLog + "}");
+                oStreamWriter.WriteLine("#config {automapper} {" + bAutoMapper + "}");
                 oStreamWriter.WriteLine("#config {editor} {" + sEditor + "}");
                 oStreamWriter.WriteLine("#config {prompt} {" + sPrompt + "}");
                 oStreamWriter.WriteLine("#config {monstercountignorelist} {" + sIgnoreMonsterList + "}");

--- a/Lists/Config.cs
+++ b/Lists/Config.cs
@@ -49,6 +49,7 @@ namespace GenieClient.Genie
         public string sLogDir = "Logs";
 
         public bool PromptBreak { get; set; } = true;
+        public bool PromptForce { get; set; } = false;
         public bool Condensed { get; set; } = false;
         public bool CheckForUpdates { get; set; } = true;
         public bool AutoUpdate { get; set; } = false;
@@ -356,6 +357,7 @@ namespace GenieClient.Genie
                 oStreamWriter.WriteLine("#config {editor} {" + sEditor + "}");
                 oStreamWriter.WriteLine("#config {prompt} {" + sPrompt + "}");
                 oStreamWriter.WriteLine("#config {promptbreak} {" + PromptBreak + "}");
+                oStreamWriter.WriteLine("#config {promptforce} {" + PromptForce + "}");
                 oStreamWriter.WriteLine("#config {condensed} {" + Condensed + "}");
                 oStreamWriter.WriteLine("#config {monstercountignorelist} {" + sIgnoreMonsterList + "}");
                 oStreamWriter.WriteLine("#config {scripttimeout} {" + iScriptTimeout + "}");
@@ -683,7 +685,26 @@ namespace GenieClient.Genie
                                 }
                                 break;
                             }
+                        case "promptforce":
+                            {
+                                switch (sValue.ToLower())
+                                {
+                                    case "on":
+                                    case "true":
+                                    case "1":
+                                        {
+                                            PromptForce = true;
+                                            break;
+                                        }
 
+                                    default:
+                                        {
+                                            PromptForce = false;
+                                            break;
+                                        }
+                                }
+                                break;
+                            }
                         case "condensed":
                             {
                                 switch (sValue.ToLower())

--- a/Lists/Config.cs
+++ b/Lists/Config.cs
@@ -48,6 +48,8 @@ namespace GenieClient.Genie
         public bool bShowLinks = false;
         public string sLogDir = "Logs";
 
+        public bool PromptBreak { get; set; } = true;
+        public bool Condensed { get; set; } = false;
         public bool CheckForUpdates { get; set; } = true;
         public bool AutoUpdate { get; set; } = false;
 
@@ -353,6 +355,8 @@ namespace GenieClient.Genie
                 oStreamWriter.WriteLine("#config {automapper} {" + bAutoMapper + "}");
                 oStreamWriter.WriteLine("#config {editor} {" + sEditor + "}");
                 oStreamWriter.WriteLine("#config {prompt} {" + sPrompt + "}");
+                oStreamWriter.WriteLine("#config {promptbreak} {" + PromptBreak + "}");
+                oStreamWriter.WriteLine("#config {condensed} {" + Condensed + "}");
                 oStreamWriter.WriteLine("#config {monstercountignorelist} {" + sIgnoreMonsterList + "}");
                 oStreamWriter.WriteLine("#config {scripttimeout} {" + iScriptTimeout + "}");
                 oStreamWriter.WriteLine("#config {maxgosubdepth} {" + iMaxGoSubDepth + "}");
@@ -656,6 +660,48 @@ namespace GenieClient.Genie
                                         }
                                 }
 
+                                break;
+                            }
+
+                        case "promptbreak":
+                            {
+                                switch (sValue.ToLower())
+                                {
+                                    case "on":
+                                    case "true":
+                                    case "1":
+                                        {
+                                            PromptBreak = true;
+                                            break;
+                                        }
+
+                                    default:
+                                        {
+                                            PromptBreak = false;
+                                            break;
+                                        }
+                                }
+                                break;
+                            }
+
+                        case "condensed":
+                            {
+                                switch (sValue.ToLower())
+                                {
+                                    case "on":
+                                    case "true":
+                                    case "1":
+                                        {
+                                            Condensed = true;
+                                            break;
+                                        }
+
+                                    default:
+                                        {
+                                            Condensed = false;
+                                            break;
+                                        }
+                                }
                                 break;
                             }
 

--- a/Lists/Globals.cs
+++ b/Lists/Globals.cs
@@ -222,6 +222,7 @@ namespace GenieClient.Genie
             sText = sText.Replace("@time@", DateTime.Now.ToString("hh:mm:ss tt").Trim());
             sText = sText.Replace("@date@", DateTime.Now.ToString("M/d/yyyy").Trim());
             sText = sText.Replace("@datetime@", DateTime.Now.ToString("M/d/yyyy hh:mm:ss tt").Trim());
+            sText = sText.Replace("@utc@", DateTimeOffset.Now.ToUnixTimeSeconds().ToString());
             return sText;
         }
 

--- a/Plugin/Plugins.vbproj
+++ b/Plugin/Plugins.vbproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>..\bin\</OutputPath>
-    <DocumentationFile>Plugins.xml</DocumentationFile>
+    <DocumentationFile></DocumentationFile>
     <BaseAddress>285212672</BaseAddress>
     <ConfigurationOverrideFile>
     </ConfigurationOverrideFile>
@@ -49,7 +49,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DocumentationFile>Plugins.xml</DocumentationFile>
+    <DocumentationFile></DocumentationFile>
     <BaseAddress>285212672</BaseAddress>
     <ConfigurationOverrideFile>
     </ConfigurationOverrideFile>

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // <Assembly: AssemblyVersion("1.0.*")> 
 
-[assembly: AssemblyVersion("4.0.2.302")]
-[assembly: AssemblyFileVersion("4.0.2.302")]
+[assembly: AssemblyVersion("4.0.2.4")]
+[assembly: AssemblyFileVersion("4.0.2.4")]

--- a/Script/Eval.cs
+++ b/Script/Eval.cs
@@ -620,224 +620,230 @@ namespace GenieClient.Genie.Script
         // Compare two sections using comparer
         private bool ParseCompare(int iArgLeft, int iArgRight, int iComparer, bool bSkipAndOr)
         {
-            double dLeftValue = -1;
-            double dRightValue = -1;
-            string sLeftValue = string.Empty;
-            string sRightValue = string.Empty;
-            bool bNumberCompare = false;
-            if (((Sections)oSections[iArgLeft]).BlockType == ParseType.NumberType & ((Sections)oSections[iArgRight]).BlockType == ParseType.NumberType)
+            try
             {
-                bNumberCompare = true;
-                dLeftValue = Utility.StringToDouble(((Sections)oSections[iArgLeft]).sBlock);
-                dRightValue = Utility.StringToDouble(((Sections)oSections[iArgRight]).sBlock);
-            }
-            else
-            {
-                sLeftValue = ((Sections)oSections[iArgLeft]).sBlock;
-                sRightValue = ((Sections)oSections[iArgRight]).sBlock;
-                Debug.Print("Compare Left: " + sLeftValue + ", Compare Right: " + sRightValue);
-            }
-
-            if (bSkipAndOr == true)
-            {
-                var switchExpr = ((Sections)oSections[iComparer]).sBlock;
-                switch (switchExpr)
+                double dLeftValue = -1;
+                double dRightValue = -1;
+                string sLeftValue = string.Empty;
+                string sRightValue = string.Empty;
+                bool bNumberCompare = false;
+                if (((Sections)oSections[iArgLeft]).BlockType == ParseType.NumberType & ((Sections)oSections[iArgRight]).BlockType == ParseType.NumberType)
                 {
-                    case "=":
-                    case "==":
-                        {
-                            // ' LINUS: Använd WITH och IIF!!
-                            // ' Koden nedan är samma som koden under, bara förenklad
-                            // With CType(oSections.Item(iArgLeft), Sections)
-                            // .sBlock = IIf(bNumberCompare, IIf(dLeftValue = dRightValue, "1", "0"), IIf(String.Equals(sLeftValue, sRightValue), "1", "0"))
-                            // .BlockType = ParseType.NumberType
-                            // .bParsed = False ' Unparse
-                            // End With
-
-                            if (bNumberCompare == true)
-                            {
-                                if (dLeftValue == dRightValue)
-                                {
-                                    ((Sections)oSections[iArgLeft]).sBlock = "1";
-                                }
-                                else
-                                {
-                                    ((Sections)oSections[iArgLeft]).sBlock = "0";
-                                }
-                            }
-                            else if (string.Equals(sLeftValue, sRightValue) == true)
-                            {
-                                ((Sections)oSections[iArgLeft]).sBlock = "1";
-                            }
-                            else
-                            {
-                                ((Sections)oSections[iArgLeft]).sBlock = "0";
-                            } ((Sections)oSections[iArgLeft]).BlockType = ParseType.NumberType;
-                            ((Sections)oSections[iArgLeft]).bParsed = false; // Unparse
-                            return true;
-                        }
-
-                    case "!=":
-                    case "<>":
-                        {
-                            if (bNumberCompare == true)
-                            {
-                                if (dLeftValue != dRightValue)
-                                {
-                                    ((Sections)oSections[iArgLeft]).sBlock = "1";
-                                }
-                                else
-                                {
-                                    ((Sections)oSections[iArgLeft]).sBlock = "0";
-                                }
-                            }
-                            else if (string.Equals(sLeftValue, sRightValue) == true)
-                            {
-                                ((Sections)oSections[iArgLeft]).sBlock = "0";
-                            }
-                            else
-                            {
-                                ((Sections)oSections[iArgLeft]).sBlock = "1";
-                            } ((Sections)oSections[iArgLeft]).BlockType = ParseType.NumberType;
-                            ((Sections)oSections[iArgLeft]).bParsed = false; // Unparse
-                            return true;
-                        }
-
-                    case ">":
-                        {
-                            if (bNumberCompare == true)
-                            {
-                                if (dLeftValue > dRightValue)
-                                {
-                                    ((Sections)oSections[iArgLeft]).sBlock = "1";
-                                }
-                                else
-                                {
-                                    ((Sections)oSections[iArgLeft]).sBlock = "0";
-                                }
-                            }
-                            else
-                            {
-                                ((Sections)oSections[iArgLeft]).sBlock = "0";
-                            } ((Sections)oSections[iArgLeft]).BlockType = ParseType.NumberType;
-                            ((Sections)oSections[iArgLeft]).bParsed = false; // Unparse
-                            return true;
-                        }
-
-                    case ">=":
-                        {
-                            if (bNumberCompare == true)
-                            {
-                                if (dLeftValue >= dRightValue)
-                                {
-                                    ((Sections)oSections[iArgLeft]).sBlock = "1";
-                                }
-                                else
-                                {
-                                    ((Sections)oSections[iArgLeft]).sBlock = "0";
-                                }
-                            }
-                            else
-                            {
-                                ((Sections)oSections[iArgLeft]).sBlock = "0";
-                            } ((Sections)oSections[iArgLeft]).BlockType = ParseType.NumberType;
-                            ((Sections)oSections[iArgLeft]).bParsed = false; // Unparse
-                            return true;
-                        }
-
-                    case "<":
-                        {
-                            if (bNumberCompare == true)
-                            {
-                                if (dLeftValue < dRightValue)
-                                {
-                                    ((Sections)oSections[iArgLeft]).sBlock = "1";
-                                }
-                                else
-                                {
-                                    ((Sections)oSections[iArgLeft]).sBlock = "0";
-                                }
-                            }
-                            else
-                            {
-                                ((Sections)oSections[iArgLeft]).sBlock = "0";
-                            } ((Sections)oSections[iArgLeft]).BlockType = ParseType.NumberType;
-                            ((Sections)oSections[iArgLeft]).bParsed = false; // Unparse
-                            return true;
-                        }
-
-                    case "<=":
-                        {
-                            if (bNumberCompare == true)
-                            {
-                                if (dLeftValue <= dRightValue)
-                                {
-                                    ((Sections)oSections[iArgLeft]).sBlock = "1";
-                                }
-                                else
-                                {
-                                    ((Sections)oSections[iArgLeft]).sBlock = "0";
-                                }
-                            }
-                            else
-                            {
-                                ((Sections)oSections[iArgLeft]).sBlock = "0";
-                            } ((Sections)oSections[iArgLeft]).BlockType = ParseType.NumberType;
-                            ((Sections)oSections[iArgLeft]).bParsed = false; // Unparse
-                            return true;
-                        }
+                    bNumberCompare = true;
+                    dLeftValue = Utility.StringToDouble(((Sections)oSections[iArgLeft]).sBlock);
+                    dRightValue = Utility.StringToDouble(((Sections)oSections[iArgRight]).sBlock);
                 }
-            }
-            else
-            {
-                var switchExpr1 = ((Sections)oSections[iComparer]).sBlock;
-                switch (switchExpr1)
+                else
                 {
-                    case "||":
-                        {
-                            if (bNumberCompare == true)
-                            {
-                                if (dLeftValue > 0 | dRightValue > 0)
-                                {
-                                    ((Sections)oSections[iArgLeft]).sBlock = "1";
-                                }
-                                else
-                                {
-                                    ((Sections)oSections[iArgLeft]).sBlock = "0";
-                                }
-                            }
-                            else
-                            {
-                                ((Sections)oSections[iArgLeft]).sBlock = "0";
-                            } ((Sections)oSections[iArgLeft]).BlockType = ParseType.NumberType;
-                            ((Sections)oSections[iArgLeft]).bParsed = false; // Unparse
-                            return true;
-                        }
-
-                    case "&&":
-                        {
-                            if (bNumberCompare == true)
-                            {
-                                if (dLeftValue > 0 & dRightValue > 0)
-                                {
-                                    ((Sections)oSections[iArgLeft]).sBlock = "1";
-                                }
-                                else
-                                {
-                                    ((Sections)oSections[iArgLeft]).sBlock = "0";
-                                }
-                            }
-                            else
-                            {
-                                ((Sections)oSections[iArgLeft]).sBlock = "0";
-                            } ((Sections)oSections[iArgLeft]).BlockType = ParseType.NumberType;
-                            ((Sections)oSections[iArgLeft]).bParsed = false; // Unparse
-                            return true;
-                        }
+                    sLeftValue = ((Sections)oSections[iArgLeft]).sBlock;
+                    sRightValue = ((Sections)oSections[iArgRight]).sBlock;
+                    Debug.Print("Compare Left: " + sLeftValue + ", Compare Right: " + sRightValue);
                 }
-            }
 
-            return false;
+                if (bSkipAndOr == true)
+                {
+                    var switchExpr = ((Sections)oSections[iComparer]).sBlock;
+                    switch (switchExpr)
+                    {
+                        case "=":
+                        case "==":
+                            {
+                                // ' LINUS: Använd WITH och IIF!!
+                                // ' Koden nedan är samma som koden under, bara förenklad
+                                // With CType(oSections.Item(iArgLeft), Sections)
+                                // .sBlock = IIf(bNumberCompare, IIf(dLeftValue = dRightValue, "1", "0"), IIf(String.Equals(sLeftValue, sRightValue), "1", "0"))
+                                // .BlockType = ParseType.NumberType
+                                // .bParsed = False ' Unparse
+                                // End With
+
+                                if (bNumberCompare == true)
+                                {
+                                    if (dLeftValue == dRightValue)
+                                    {
+                                        ((Sections)oSections[iArgLeft]).sBlock = "1";
+                                    }
+                                    else
+                                    {
+                                        ((Sections)oSections[iArgLeft]).sBlock = "0";
+                                    }
+                                }
+                                else if (string.Equals(sLeftValue, sRightValue) == true)
+                                {
+                                    ((Sections)oSections[iArgLeft]).sBlock = "1";
+                                }
+                                else
+                                {
+                                    ((Sections)oSections[iArgLeft]).sBlock = "0";
+                                } ((Sections)oSections[iArgLeft]).BlockType = ParseType.NumberType;
+                                ((Sections)oSections[iArgLeft]).bParsed = false; // Unparse
+                                return true;
+                            }
+
+                        case "!=":
+                        case "<>":
+                            {
+                                if (bNumberCompare == true)
+                                {
+                                    if (dLeftValue != dRightValue)
+                                    {
+                                        ((Sections)oSections[iArgLeft]).sBlock = "1";
+                                    }
+                                    else
+                                    {
+                                        ((Sections)oSections[iArgLeft]).sBlock = "0";
+                                    }
+                                }
+                                else if (string.Equals(sLeftValue, sRightValue) == true)
+                                {
+                                    ((Sections)oSections[iArgLeft]).sBlock = "0";
+                                }
+                                else
+                                {
+                                    ((Sections)oSections[iArgLeft]).sBlock = "1";
+                                } ((Sections)oSections[iArgLeft]).BlockType = ParseType.NumberType;
+                                ((Sections)oSections[iArgLeft]).bParsed = false; // Unparse
+                                return true;
+                            }
+
+                        case ">":
+                            {
+                                if (bNumberCompare == true)
+                                {
+                                    if (dLeftValue > dRightValue)
+                                    {
+                                        ((Sections)oSections[iArgLeft]).sBlock = "1";
+                                    }
+                                    else
+                                    {
+                                        ((Sections)oSections[iArgLeft]).sBlock = "0";
+                                    }
+                                }
+                                else
+                                {
+                                    ((Sections)oSections[iArgLeft]).sBlock = "0";
+                                } ((Sections)oSections[iArgLeft]).BlockType = ParseType.NumberType;
+                                ((Sections)oSections[iArgLeft]).bParsed = false; // Unparse
+                                return true;
+                            }
+
+                        case ">=":
+                            {
+                                if (bNumberCompare == true)
+                                {
+                                    if (dLeftValue >= dRightValue)
+                                    {
+                                        ((Sections)oSections[iArgLeft]).sBlock = "1";
+                                    }
+                                    else
+                                    {
+                                        ((Sections)oSections[iArgLeft]).sBlock = "0";
+                                    }
+                                }
+                                else
+                                {
+                                    ((Sections)oSections[iArgLeft]).sBlock = "0";
+                                } ((Sections)oSections[iArgLeft]).BlockType = ParseType.NumberType;
+                                ((Sections)oSections[iArgLeft]).bParsed = false; // Unparse
+                                return true;
+                            }
+
+                        case "<":
+                            {
+                                if (bNumberCompare == true)
+                                {
+                                    if (dLeftValue < dRightValue)
+                                    {
+                                        ((Sections)oSections[iArgLeft]).sBlock = "1";
+                                    }
+                                    else
+                                    {
+                                        ((Sections)oSections[iArgLeft]).sBlock = "0";
+                                    }
+                                }
+                                else
+                                {
+                                    ((Sections)oSections[iArgLeft]).sBlock = "0";
+                                } ((Sections)oSections[iArgLeft]).BlockType = ParseType.NumberType;
+                                ((Sections)oSections[iArgLeft]).bParsed = false; // Unparse
+                                return true;
+                            }
+
+                        case "<=":
+                            {
+                                if (bNumberCompare == true)
+                                {
+                                    if (dLeftValue <= dRightValue)
+                                    {
+                                        ((Sections)oSections[iArgLeft]).sBlock = "1";
+                                    }
+                                    else
+                                    {
+                                        ((Sections)oSections[iArgLeft]).sBlock = "0";
+                                    }
+                                }
+                                else
+                                {
+                                    ((Sections)oSections[iArgLeft]).sBlock = "0";
+                                } ((Sections)oSections[iArgLeft]).BlockType = ParseType.NumberType;
+                                ((Sections)oSections[iArgLeft]).bParsed = false; // Unparse
+                                return true;
+                            }
+                    }
+                }
+                else
+                {
+                    var switchExpr1 = ((Sections)oSections[iComparer]).sBlock;
+                    switch (switchExpr1)
+                    {
+                        case "||":
+                            {
+                                if (bNumberCompare == true)
+                                {
+                                    if (dLeftValue > 0 | dRightValue > 0)
+                                    {
+                                        ((Sections)oSections[iArgLeft]).sBlock = "1";
+                                    }
+                                    else
+                                    {
+                                        ((Sections)oSections[iArgLeft]).sBlock = "0";
+                                    }
+                                }
+                                else
+                                {
+                                    ((Sections)oSections[iArgLeft]).sBlock = "0";
+                                } ((Sections)oSections[iArgLeft]).BlockType = ParseType.NumberType;
+                                ((Sections)oSections[iArgLeft]).bParsed = false; // Unparse
+                                return true;
+                            }
+
+                        case "&&":
+                            {
+                                if (bNumberCompare == true)
+                                {
+                                    if (dLeftValue > 0 & dRightValue > 0)
+                                    {
+                                        ((Sections)oSections[iArgLeft]).sBlock = "1";
+                                    }
+                                    else
+                                    {
+                                        ((Sections)oSections[iArgLeft]).sBlock = "0";
+                                    }
+                                }
+                                else
+                                {
+                                    ((Sections)oSections[iArgLeft]).sBlock = "0";
+                                } ((Sections)oSections[iArgLeft]).BlockType = ParseType.NumberType;
+                                ((Sections)oSections[iArgLeft]).bParsed = false; // Unparse
+                                return true;
+                            }
+                    }
+                }
+                return false;
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         private Genie.Collections.ArrayList m_RegExpResultList = new Genie.Collections.ArrayList();

--- a/Utility/Utility.cs
+++ b/Utility/Utility.cs
@@ -562,21 +562,7 @@ namespace GenieClient
                 double d = double.Parse(sValue, new System.Globalization.CultureInfo("en-US"));
                 return d;
             }
-            #pragma warning disable CS0168
-            catch (FormatException ex)
-            #pragma warning restore CS0168
-            {
-                return -1;
-            }
-            #pragma warning disable CS0168
-            catch (OverflowException ex)
-            #pragma warning restore CS0168
-            {
-                return -1;
-            }
-            #pragma warning disable CS0168
-            catch (InvalidCastException ex)
-            #pragma warning restore CS0168
+            catch 
             {
                 return -1;
             }
@@ -601,21 +587,7 @@ namespace GenieClient
                     return -1;
                 }
             }
-            #pragma warning disable CS0168
-            catch (FormatException ex)
-            #pragma warning restore CS0168
-            {
-                return -1;
-            }
-            #pragma warning disable CS0168
-            catch (OverflowException ex)
-            #pragma warning restore CS0168
-            {
-                return -1;
-            }
-            #pragma warning disable CS0168
-            catch (InvalidCastException ex)
-            #pragma warning restore CS0168
+            catch 
             {
                 return -1;
             }


### PR DESCRIPTION
Addresses #22 #31 #40 #59
robustified some error handling in evals to return false or -1 as appropriate rather than throw errors
added Gemstone instances to game list, removed Alliance of Heroes and Modus Operandi
added https://github.com/UTC@ to provide the current utc unix timestamp in seconds, which should approximately match current $gametime
added three new stream display settings
promptbreak is TRUE by deffault, and inserts a line break before a status prompt
promptforce is FALSE by default and forces printing of every prompt
condensed is FALSE by default and removes all line breaks
the default settings mirror the Genie 3.6 stream flow, you can use these to find the flow you like
added a linebreak after the update notifications
updated placement and flow of status prompt
triggered immediate parsing of each XML node's data
Restricted custom parsing around "You always see" to only trigger when it's the start of a line while parsing a room description
fixed highlight inconsistencies which caused some highlights to apply out of scope
resolved pushBold/popBold issues