### PR TITLE
Prevented printing of lines which are only XML and \r\n

### DIFF
--- a/Core/Game.cs
+++ b/Core/Game.cs
@@ -515,6 +515,7 @@ namespace GenieClient.Genie
         public void ParseGameRow(string sText)
         {
             var oXMLBuffer = new StringBuilder();
+            bool hasXML = false;
             int iInsideXML = 0;
             bool bEndTagFound = false;
             bool bInsideHTMLTag = false;
@@ -548,6 +549,7 @@ namespace GenieClient.Genie
                     case '<':
                         {
                             iInsideXML += 1;
+                            hasXML = true;
                             oXMLBuffer.Append(c);
                             break;
                         }
@@ -785,10 +787,13 @@ namespace GenieClient.Genie
                     }
                 }
 
+                if (!(sTextBuffer == "\r\n" && hasXML))
+                {
+                    bool argbIsPrompt1 = false;
+                    WindowTarget argoWindowTarget1 = 0;
+                    PrintTextWithParse(sTextBuffer, bIsPrompt: argbIsPrompt1, oWindowTarget: argoWindowTarget1);
+                }
                 
-                bool argbIsPrompt1 = false;
-                WindowTarget argoWindowTarget1 = 0;
-                PrintTextWithParse(sTextBuffer, bIsPrompt: argbIsPrompt1, oWindowTarget: argoWindowTarget1);
                 
                 if (bCombatRow == true)
                 {


### PR DESCRIPTION
1 - added a new bool, hasXML
2 - At line 552 I flip hasXML to true every time it detects that it's going into XML - never turns it off, it starts off and if the line doesn't have XML it never hits
3 - down towards the end of the function around 790 I wrapped the function to ParseText in a check for the line to not be XML with only a line break. Including other whitespace characters will pass this check.