### PR TITLE
VolatileHighlights Duplicate Fix

### DIFF
--- a/Core/Game.cs
+++ b/Core/Game.cs
@@ -522,6 +522,7 @@ namespace GenieClient.Genie
             string sHTMLBuffer = string.Empty;
             string sTextBuffer = string.Empty;
             string sBoldBuffer = string.Empty;
+            int iBoldIndex = 0;
             char cPreviousChar = Conversions.ToChar("");
             bool bCombatRow = false;
             bool bPromptRow = false;
@@ -592,7 +593,7 @@ namespace GenieClient.Genie
                                             break;
                                     }
                                     sTmp = ParseSubstitutions(sTmp);
-                                    m_oGlobals.VolatileHighlights.Add(new System.Collections.Generic.KeyValuePair<string, string>(presetLabel, sTmp));
+                                    m_oGlobals.VolatileHighlights.Add(new VolatileHighlight(sTmp, presetLabel, 0));
                                     if(presetLabel == "roomdesc")
                                     {
                                         PrintTextWithParse(sTmp, bIsPrompt: false, oWindowTarget: 0);
@@ -602,13 +603,14 @@ namespace GenieClient.Genie
                                 if (buffer.EndsWith(@"<pushBold/>"))
                                 {
                                     sBoldBuffer = string.Empty;
+                                    iBoldIndex = sTextBuffer.Length; //do not subtract 1 because our start index isn't added yet
                                 }
                                 if (buffer.EndsWith(@"<popBold/>"))
                                 {
                                     if (!string.IsNullOrWhiteSpace(sBoldBuffer))
                                     {
                                         sBoldBuffer = ParseSubstitutions(sBoldBuffer);
-                                        m_oGlobals.VolatileHighlights.Add(new System.Collections.Generic.KeyValuePair<string, string>("creatures", sBoldBuffer));
+                                        m_oGlobals.VolatileHighlights.Add(new VolatileHighlight(sBoldBuffer, "creatures", iBoldIndex));
                                     }
                                 }
                                 if (m_bBold)
@@ -765,7 +767,7 @@ namespace GenieClient.Genie
                 else if (!string.IsNullOrWhiteSpace(sBoldBuffer))
                 {
                     sBoldBuffer = ParseSubstitutions(sBoldBuffer);
-                    m_oGlobals.VolatileHighlights.Add(new System.Collections.Generic.KeyValuePair<string, string>("creatures", sBoldBuffer.Trim())); //trim because excessive whitespace seems to be breaking this
+                    m_oGlobals.VolatileHighlights.Add(new VolatileHighlight(sBoldBuffer.Trim(), "creatures", iBoldIndex)); //trim because excessive whitespace seems to be breaking this
                     sBoldBuffer = string.Empty;
                 }
 

--- a/Forms/Components/ComponentRichTextBox.cs
+++ b/Forms/Components/ComponentRichTextBox.cs
@@ -508,43 +508,46 @@ namespace GenieClient
             }
 
             // Presets and Bold
-            if (m_oParentForm.Globals.VolatileHighlights.Count > 0)
+            foreach (VolatileHighlight highlight in m_oParentForm.Globals.VolatileHighlights.ToArray())
             {
-                foreach (KeyValuePair<string, string> highlight in m_oParentForm.Globals.VolatileHighlights.ToArray())
+                int runningPosition = 0;
+                Regex volatileRegex = new Regex(Regex.Escape(highlight));
+                foreach(string line in m_oRichTextBuffer.Text.Split('\n')) 
                 {
-                    Regex volatileRegex = new Regex(Regex.Escape(highlight.Value));
-                    oMatchCollection = volatileRegex.Matches(m_oRichTextBuffer.Text);
+                    int timestampOffset = 0;
+                    if (m_bTimeStamp)
                     {
-                        foreach (Match oMatch in oMatchCollection)
-                        {
-                            if (m_oParentForm.Globals.PresetList[highlight.Key].bHighlightLine)
-                            {
-                                int indexOfHighlight = m_oRichTextBuffer.Text.IndexOf(highlight.Value);
-                                int lastNewLineIndex = m_oRichTextBuffer.Text.LastIndexOf("\n", indexOfHighlight);
-                                int nextNewLineIndex = m_oRichTextBuffer.Text.IndexOf("\n", indexOfHighlight);
-                                if (lastNewLineIndex == -1) lastNewLineIndex = 0;
-                                if (nextNewLineIndex == -1) nextNewLineIndex = m_oRichTextBuffer.Text.Length;
-                                m_oRichTextBuffer.SelectionStart = lastNewLineIndex >= 0 ? lastNewLineIndex : 0;
-                                m_oRichTextBuffer.SelectionLength = nextNewLineIndex - lastNewLineIndex;
-                            }
-                            else
-                            {
-                                m_oRichTextBuffer.SelectionStart = oMatch.Groups[0].Index;
-                                m_oRichTextBuffer.SelectionLength = oMatch.Groups[0].Length;
-                            }
-                            if (!Operators.ConditionalCompareObjectEqual(m_oParentForm.Globals.PresetList[highlight.Key].FgColor, Color.Transparent, false))
-                            {
-                                m_oRichTextBuffer.SelectionColor = (Color)m_oParentForm.Globals.PresetList[highlight.Key].FgColor;
-                            }
-
-                            if (!Operators.ConditionalCompareObjectEqual(m_oParentForm.Globals.PresetList[highlight.Key].BgColor, Color.Transparent, false))
-                            {
-                                m_oRichTextBuffer.SelectionBackColor = (Color)m_oParentForm.Globals.PresetList[highlight.Key].BgColor;
-                            }
-                        }
+                        timestampOffset += GetTimeString(line).Length;
                     }
+                    if (m_oParentForm.Globals.PresetList[highlight.Preset].bHighlightLine)
+                    {
+                        int indexOfHighlight = m_oRichTextBuffer.Text.IndexOf(highlight);
+                        int lastNewLineIndex = m_oRichTextBuffer.Text.LastIndexOf("\n", indexOfHighlight);
+                        int nextNewLineIndex = m_oRichTextBuffer.Text.IndexOf("\n", indexOfHighlight);
+                        if (lastNewLineIndex == -1) lastNewLineIndex = 0;
+                        if (nextNewLineIndex == -1) nextNewLineIndex = m_oRichTextBuffer.Text.Length;
+                        m_oRichTextBuffer.SelectionStart = lastNewLineIndex >= 0 ? lastNewLineIndex : 0;
+                        m_oRichTextBuffer.SelectionLength = nextNewLineIndex - lastNewLineIndex;
+                    }
+                    else if(line.Length >= highlight.EndIndex + timestampOffset && line.Substring(highlight.StartIndex + timestampOffset, highlight.Length) == highlight)
+                    {
+                        m_oRichTextBuffer.SelectionStart = runningPosition + timestampOffset + highlight.StartIndex;
+                        m_oRichTextBuffer.SelectionLength = highlight.Length;
+                    }
+                    if (!Operators.ConditionalCompareObjectEqual(m_oParentForm.Globals.PresetList[highlight.Preset].FgColor, Color.Transparent, false))
+                    {
+                        m_oRichTextBuffer.SelectionColor = (Color)m_oParentForm.Globals.PresetList[highlight.Preset].FgColor;
+                    }
+
+                    if (!Operators.ConditionalCompareObjectEqual(m_oParentForm.Globals.PresetList[highlight.Preset].BgColor, Color.Transparent, false))
+                    {
+                        m_oRichTextBuffer.SelectionBackColor = (Color)m_oParentForm.Globals.PresetList[highlight.Preset].BgColor;
+                    }
+                    runningPosition += line.Length + 1; //add 1 to account for the \n characters removed by the split
                 }
+                
             }
+            
 
             // Highlight String
             if (!Information.IsNothing(m_oParentForm.Globals.HighlightList.RegexString))

--- a/Lists/Globals.cs
+++ b/Lists/Globals.cs
@@ -114,7 +114,7 @@ namespace GenieClient.Genie
         }
 
         public List<string> MonsterList = new List<string>();
-        public List<KeyValuePair<string, string>> VolatileHighlights = new List<KeyValuePair<string, string>>();
+        public List<VolatileHighlight> VolatileHighlights = new List<VolatileHighlight>();
         public List<KeyValuePair<string, string>> RoomObjects = new List<KeyValuePair<string, string>>();
         public Regex MonsterListRegEx;
 

--- a/Lists/VolatileHighlight.cs
+++ b/Lists/VolatileHighlight.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GenieClient.Genie
+{
+    public class VolatileHighlight
+    {
+        public string Text { get; set; }
+        public string Preset { get; set; }
+        public int StartIndex { get; set; }
+        public int Length { get { return Text.Length; } }
+        public int EndIndex { get { return StartIndex + Length; } }
+        public VolatileHighlight(string HighlightText, string PresetLabel, int StartPosition)
+        {
+            Text = HighlightText;
+            Preset = PresetLabel;
+            StartIndex = StartPosition;
+        }
+        public static implicit operator string(VolatileHighlight highlight)
+        {
+            return highlight.Text;
+        }
+    }
+}


### PR DESCRIPTION
Rewrote handling of VolatileHighlights to singularly target the highlight instead of using Regex

Previously, we were using Regex to detect the position of the highlight in the string and apply, which was causing it to apply to every instance of the highlight even when those were not bolded. For example, if the number 1 were bolded on the first line of lich's circlecheck, every instance of the number 1 would be highlighted in the entire table. 

Added a VolatileHighlight class to hold the properties of the highlight.
Added iBoldIndex to Game.cs to track the start position of sBoldBuffer when it pushBold is detected
Changed the VolatileHighlights List type from KeyValuePair to VolatileHighlight
Reworked logic when applying VolatileHighlights to exactly target the substring position of the highlight