### PR TITLE
Changed XML Load to infer Encoding

### DIFF
--- a/Mapper/AutoMapper.cs
+++ b/Mapper/AutoMapper.cs
@@ -243,7 +243,8 @@ namespace GenieClient.Mapper
                         if ((dif.Extension.ToLower() ?? "") == ".xml")
                     {
                         xdoc = new XmlDocument();
-                        xdoc.Load(dif.FullName);
+                        
+                        xdoc.Load(new StreamReader(dif.FullName,true));
                         xnlist = xdoc.SelectNodes("zone/node");
                         foreach (XmlNode xn in xnlist)
                         {
@@ -300,7 +301,7 @@ namespace GenieClient.Mapper
                 if ((dif.Extension.ToLower() ?? "") == ".xml")
                 {
                     xdoc = new XmlDocument();
-                    xdoc.Load(dif.FullName);
+                    xdoc.Load(new StreamReader(dif.FullName, true));
                     xnlist = xdoc.SelectNodes("zone/node");
                     foreach (XmlNode xn in xnlist)
                     {

--- a/Mapper/MapForm.cs
+++ b/Mapper/MapForm.cs
@@ -536,7 +536,7 @@ namespace GenieClient.Mapper
                 }
 
                 xdoc = new XmlDocument();
-                xdoc.Load(sPath);
+                xdoc.Load(new StreamReader(sPath, true));
                 var z = new Zone();
                 var xZone = xdoc.SelectSingleNode("zone");
                 if (!Information.IsNothing(xZone))
@@ -618,7 +618,7 @@ namespace GenieClient.Mapper
                     return false;
                 m_CurrentMapFile = sPath;
                 xdoc = new XmlDocument();
-                xdoc.Load(sPath);
+                xdoc.Load(new StreamReader(sPath, true));
                 var xZone = xdoc.SelectSingleNode("zone");
                 if (!Information.IsNothing(xZone))
                 {

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // <Assembly: AssemblyVersion("1.0.*")> 
 
-[assembly: AssemblyVersion("4.0.2.4")]
-[assembly: AssemblyFileVersion("4.0.2.4")]
+[assembly: AssemblyVersion("4.0.2.404")]
+[assembly: AssemblyFileVersion("4.0.2.404")]


### PR DESCRIPTION
To address instances where the Mapper fails to load maps due to them having a different encoding than declared, I have changed calls to XmlDocument.Load to use a new StreamReader which infers Encoding from the Byte Order instead of trusting the declared encoding in the header.