### PR TITLE
Added parsing for all Highlight options from the command

### DIFF
--- a/Core/Command.cs
+++ b/Core/Command.cs
@@ -1890,8 +1890,13 @@ namespace GenieClient.Genie
                                                             if (oArgs.Count > 3)
                                                             {
                                                                 string argsKey = oGlobals.ParseGlobalVars(Utility.ArrayToString(oArgs, 3));
-                                                                bool argbHighlightWholeRow = true;
-                                                                oGlobals.HighlightList.Add(argsKey, argbHighlightWholeRow, oGlobals.ParseGlobalVars(oArgs[2].ToString()));
+                                                                bool highlightWholeRow = true;
+                                                                string color = oGlobals.ParseGlobalVars(oArgs[2].ToString());
+                                                                bool caseSensitive = oArgs.Count > 4 ? oArgs[4].ToString().ToUpper() == "TRUE" : false;
+                                                                string soundFile = oArgs.Count > 5 ? oArgs[5].ToString() : string.Empty;
+                                                                string className = oArgs.Count > 6 ? oArgs[6].ToString() : string.Empty;
+                                                                bool isActive = oArgs.Count > 7 ? oArgs[7].ToString().ToUpper() == "TRUE" : true;
+                                                                oGlobals.HighlightList.Add(argsKey, highlightWholeRow, color, caseSensitive, soundFile, className, isActive);
                                                                 oGlobals.HighlightList.RebuildLineIndex();
                                                             }
 
@@ -1903,9 +1908,14 @@ namespace GenieClient.Genie
                                                         {
                                                             if (oArgs.Count > 3)
                                                             {
-                                                                string argsKey1 = oGlobals.ParseGlobalVars(Utility.ArrayToString(oArgs, 3));
-                                                                bool argbHighlightWholeRow1 = false;
-                                                                oGlobals.HighlightList.Add(argsKey1, argbHighlightWholeRow1, oGlobals.ParseGlobalVars(oArgs[2].ToString()));
+                                                                string highlightText = oGlobals.ParseGlobalVars(Utility.ArrayToString(oArgs, 3));
+                                                                bool highlightWholeRow = false;
+                                                                string color = oGlobals.ParseGlobalVars(oArgs[2].ToString());
+                                                                bool caseSensitive = oArgs.Count > 4 ? oArgs[4].ToString().ToUpper() == "TRUE" : false;
+                                                                string soundFile = oArgs.Count > 5 ? oArgs[5].ToString() : string.Empty;
+                                                                string className = oArgs.Count > 6 ? oArgs[6].ToString() : string.Empty;
+                                                                bool isActive = oArgs.Count > 7 ? oArgs[7].ToString().ToUpper() == "TRUE" : true;
+                                                                oGlobals.HighlightList.Add(highlightText, highlightWholeRow, color , caseSensitive, soundFile, className, isActive);
                                                                 oGlobals.HighlightList.RebuildStringIndex();
                                                             }
 
@@ -1916,9 +1926,13 @@ namespace GenieClient.Genie
                                                         {
                                                             if (oArgs.Count > 3)
                                                             {
-                                                                string argsKey2 = oGlobals.ParseGlobalVars(Utility.ArrayToString(oArgs, 3));
-                                                                string argsColorName = oGlobals.ParseGlobalVars(oArgs[2].ToString());
-                                                                oGlobals.HighlightBeginsWithList.Add(argsKey2, argsColorName);
+                                                                string beginsWithText = oGlobals.ParseGlobalVars(Utility.ArrayToString(oArgs, 3));
+                                                                string color = oGlobals.ParseGlobalVars(oArgs[2].ToString());
+                                                                bool caseSensitive = oArgs.Count > 4 ? oArgs[4].ToString().ToUpper() == "TRUE" : false;
+                                                                string soundFile = oArgs.Count > 5 ? oArgs[5].ToString() : string.Empty;
+                                                                string className = oArgs.Count > 6 ? oArgs[6].ToString() : string.Empty;
+                                                                bool isActive = oArgs.Count > 7 ? oArgs[7].ToString().ToUpper() == "TRUE" : true;
+                                                                oGlobals.HighlightBeginsWithList.Add(beginsWithText, color, caseSensitive, soundFile, className, isActive);
                                                             }
 
                                                             break;
@@ -1932,9 +1946,13 @@ namespace GenieClient.Genie
                                                                 string argsRegExp = oGlobals.ParseGlobalVars(Utility.ArrayToString(oArgs, 3));
                                                                 if (Utility.ValidateRegExp(argsRegExp) == true)
                                                                 {
-                                                                    string argsKey3 = oGlobals.ParseGlobalVars(Utility.ArrayToString(oArgs, 3));
-                                                                    string argsColorName1 = oGlobals.ParseGlobalVars(oArgs[2].ToString());
-                                                                    oGlobals.HighlightRegExpList.Add(argsKey3, argsColorName1);
+                                                                    string regexPattern = oGlobals.ParseGlobalVars(Utility.ArrayToString(oArgs, 3));
+                                                                    string color = oGlobals.ParseGlobalVars(oArgs[2].ToString());
+                                                                    bool caseSensitive = oArgs.Count > 4 ? oArgs[4].ToString().ToUpper() == "TRUE" : false;
+                                                                    string soundFile = oArgs.Count > 5 ? oArgs[5].ToString() : string.Empty;
+                                                                    string className = oArgs.Count > 6 ? oArgs[6].ToString() : string.Empty;
+                                                                    bool isActive = oArgs.Count > 7 ? oArgs[7].ToString().ToUpper() == "TRUE" : true;
+                                                                    oGlobals.HighlightRegExpList.Add(regexPattern, color, caseSensitive, soundFile, className, isActive);
                                                                 }
                                                                 else
                                                                 {


### PR DESCRIPTION
I added parsing for each possible parameter that can be passed to the highlight list 
syntax: #highlight {string/line/regex/beginswith} {color} {text/pattern} {Case Sensitive} {Sound File} {Class Name} {Active}
case sensitive defaults false, active defaults true (this is already the case, now it can be controlled)
to set true you must use the word true, a 1 does not flag
Due to other functionality with the parameter list for #highlight name that part of the command cannot be expanded
