### PR TITLE
Dev 4 0 2 5

### DIFF
--- a/Core/Command.cs
+++ b/Core/Command.cs
@@ -1890,8 +1890,13 @@ namespace GenieClient.Genie
                                                             if (oArgs.Count > 3)
                                                             {
                                                                 string argsKey = oGlobals.ParseGlobalVars(Utility.ArrayToString(oArgs, 3));
-                                                                bool argbHighlightWholeRow = true;
-                                                                oGlobals.HighlightList.Add(argsKey, argbHighlightWholeRow, oGlobals.ParseGlobalVars(oArgs[2].ToString()));
+                                                                bool highlightWholeRow = true;
+                                                                string color = oGlobals.ParseGlobalVars(oArgs[2].ToString());
+                                                                bool caseSensitive = oArgs.Count > 4 ? oArgs[4].ToString().ToUpper() == "TRUE" : false;
+                                                                string soundFile = oArgs.Count > 5 ? oArgs[5].ToString() : string.Empty;
+                                                                string className = oArgs.Count > 6 ? oArgs[6].ToString() : string.Empty;
+                                                                bool isActive = oArgs.Count > 7 ? oArgs[7].ToString().ToUpper() == "TRUE" : true;
+                                                                oGlobals.HighlightList.Add(argsKey, highlightWholeRow, color, caseSensitive, soundFile, className, isActive);
                                                                 oGlobals.HighlightList.RebuildLineIndex();
                                                             }
 
@@ -1903,9 +1908,14 @@ namespace GenieClient.Genie
                                                         {
                                                             if (oArgs.Count > 3)
                                                             {
-                                                                string argsKey1 = oGlobals.ParseGlobalVars(Utility.ArrayToString(oArgs, 3));
-                                                                bool argbHighlightWholeRow1 = false;
-                                                                oGlobals.HighlightList.Add(argsKey1, argbHighlightWholeRow1, oGlobals.ParseGlobalVars(oArgs[2].ToString()));
+                                                                string highlightText = oGlobals.ParseGlobalVars(Utility.ArrayToString(oArgs, 3));
+                                                                bool highlightWholeRow = false;
+                                                                string color = oGlobals.ParseGlobalVars(oArgs[2].ToString());
+                                                                bool caseSensitive = oArgs.Count > 4 ? oArgs[4].ToString().ToUpper() == "TRUE" : false;
+                                                                string soundFile = oArgs.Count > 5 ? oArgs[5].ToString() : string.Empty;
+                                                                string className = oArgs.Count > 6 ? oArgs[6].ToString() : string.Empty;
+                                                                bool isActive = oArgs.Count > 7 ? oArgs[7].ToString().ToUpper() == "TRUE" : true;
+                                                                oGlobals.HighlightList.Add(highlightText, highlightWholeRow, color , caseSensitive, soundFile, className, isActive);
                                                                 oGlobals.HighlightList.RebuildStringIndex();
                                                             }
 
@@ -1916,9 +1926,13 @@ namespace GenieClient.Genie
                                                         {
                                                             if (oArgs.Count > 3)
                                                             {
-                                                                string argsKey2 = oGlobals.ParseGlobalVars(Utility.ArrayToString(oArgs, 3));
-                                                                string argsColorName = oGlobals.ParseGlobalVars(oArgs[2].ToString());
-                                                                oGlobals.HighlightBeginsWithList.Add(argsKey2, argsColorName);
+                                                                string beginsWithText = oGlobals.ParseGlobalVars(Utility.ArrayToString(oArgs, 3));
+                                                                string color = oGlobals.ParseGlobalVars(oArgs[2].ToString());
+                                                                bool caseSensitive = oArgs.Count > 4 ? oArgs[4].ToString().ToUpper() == "TRUE" : false;
+                                                                string soundFile = oArgs.Count > 5 ? oArgs[5].ToString() : string.Empty;
+                                                                string className = oArgs.Count > 6 ? oArgs[6].ToString() : string.Empty;
+                                                                bool isActive = oArgs.Count > 7 ? oArgs[7].ToString().ToUpper() == "TRUE" : true;
+                                                                oGlobals.HighlightBeginsWithList.Add(beginsWithText, color, caseSensitive, soundFile, className, isActive);
                                                             }
 
                                                             break;
@@ -1932,9 +1946,13 @@ namespace GenieClient.Genie
                                                                 string argsRegExp = oGlobals.ParseGlobalVars(Utility.ArrayToString(oArgs, 3));
                                                                 if (Utility.ValidateRegExp(argsRegExp) == true)
                                                                 {
-                                                                    string argsKey3 = oGlobals.ParseGlobalVars(Utility.ArrayToString(oArgs, 3));
-                                                                    string argsColorName1 = oGlobals.ParseGlobalVars(oArgs[2].ToString());
-                                                                    oGlobals.HighlightRegExpList.Add(argsKey3, argsColorName1);
+                                                                    string regexPattern = oGlobals.ParseGlobalVars(Utility.ArrayToString(oArgs, 3));
+                                                                    string color = oGlobals.ParseGlobalVars(oArgs[2].ToString());
+                                                                    bool caseSensitive = oArgs.Count > 4 ? oArgs[4].ToString().ToUpper() == "TRUE" : false;
+                                                                    string soundFile = oArgs.Count > 5 ? oArgs[5].ToString() : string.Empty;
+                                                                    string className = oArgs.Count > 6 ? oArgs[6].ToString() : string.Empty;
+                                                                    bool isActive = oArgs.Count > 7 ? oArgs[7].ToString().ToUpper() == "TRUE" : true;
+                                                                    oGlobals.HighlightRegExpList.Add(regexPattern, color, caseSensitive, soundFile, className, isActive);
                                                                 }
                                                                 else
                                                                 {

--- a/Core/Command.cs
+++ b/Core/Command.cs
@@ -2877,6 +2877,7 @@ namespace GenieClient.Genie
             EchoText("mapdir=" + oGlobals.Config.sMapDir + System.Environment.NewLine);
             EchoText("scriptdir=" + oGlobals.Config.sScriptDir + System.Environment.NewLine);
             EchoText("scriptchar=" + oGlobals.Config.ScriptChar.ToString() + System.Environment.NewLine);
+            EchoText("scriptrepo=" + oGlobals.Config.ScriptRepo + System.Environment.NewLine);
             EchoText("scriptextension=" + oGlobals.Config.ScriptExtension + System.Environment.NewLine);
             EchoText("scripttimeout=" + oGlobals.Config.iScriptTimeout.ToString() + System.Environment.NewLine);
             EchoText("separatorchar=" + oGlobals.Config.cSeparatorChar.ToString() + System.Environment.NewLine);

--- a/Core/Game.cs
+++ b/Core/Game.cs
@@ -612,7 +612,7 @@ namespace GenieClient.Genie
                                         m_oGlobals.VolatileHighlights.Add(new VolatileHighlight(sBoldBuffer, "creatures", iBoldIndex));
                                     }
                                 }
-                                if (m_bBold)
+                                if (m_bBold & !m_oGlobals.Config.Condensed)
                                 {
                                     if (sTextBuffer.StartsWith("< ") | sTextBuffer.StartsWith("> ") | sTextBuffer.StartsWith("* "))
                                     {
@@ -623,6 +623,7 @@ namespace GenieClient.Genie
                                         PrintTextWithParse(argsText, bIsPrompt: argbIsPrompt, oWindowTarget: argoWindowTarget);
                                         m_bBold = true;
                                         sTextBuffer = string.Empty;
+                                        iBoldIndex = sTextBuffer.Length;
                                         bCombatRow = true;
                                     }
                                 }

--- a/Core/Game.cs
+++ b/Core/Game.cs
@@ -515,6 +515,7 @@ namespace GenieClient.Genie
         public void ParseGameRow(string sText)
         {
             var oXMLBuffer = new StringBuilder();
+            bool hasXML = false;
             int iInsideXML = 0;
             bool bEndTagFound = false;
             bool bInsideHTMLTag = false;
@@ -548,6 +549,7 @@ namespace GenieClient.Genie
                     case '<':
                         {
                             iInsideXML += 1;
+                            hasXML = true;
                             oXMLBuffer.Append(c);
                             break;
                         }
@@ -785,10 +787,13 @@ namespace GenieClient.Genie
                     }
                 }
 
+                if (!(sTextBuffer == "\r\n" && hasXML))
+                {
+                    bool argbIsPrompt1 = false;
+                    WindowTarget argoWindowTarget1 = 0;
+                    PrintTextWithParse(sTextBuffer, bIsPrompt: argbIsPrompt1, oWindowTarget: argoWindowTarget1);
+                }
                 
-                bool argbIsPrompt1 = false;
-                WindowTarget argoWindowTarget1 = 0;
-                PrintTextWithParse(sTextBuffer, bIsPrompt: argbIsPrompt1, oWindowTarget: argoWindowTarget1);
                 
                 if (bCombatRow == true)
                 {

--- a/Core/Game.cs
+++ b/Core/Game.cs
@@ -592,7 +592,6 @@ namespace GenieClient.Genie
                                         default:
                                             break;
                                     }
-                                    sTmp = ParseSubstitutions(sTmp);
                                     m_oGlobals.VolatileHighlights.Add(new VolatileHighlight(sTmp, presetLabel, 0));
                                     if(presetLabel == "roomdesc")
                                     {

--- a/Core/Game.cs
+++ b/Core/Game.cs
@@ -2649,7 +2649,7 @@ namespace GenieClient.Genie
             {
                 if (sText.StartsWith("  You also see"))
                 {
-                    PrintTextToWindow(Environment.NewLine, color, bgcolor);
+                    PrintTextToWindow(Environment.NewLine, color, bgcolor, oWindowTarget, bIsPrompt, true);
                     sText = sText.TrimStart();
                 }
 
@@ -2756,7 +2756,7 @@ namespace GenieClient.Genie
 
         private void PrintTextToWindow(string text, Color color, Color bgcolor, WindowTarget targetwindow = WindowTarget.Main, bool isprompt = false, bool isroomoutput = false)
         {
-            if (text.Length == 0 || (m_oGlobals.Config.Condensed && text.Trim().Length == 0))
+            if (text.Length == 0 || (!isroomoutput && m_oGlobals.Config.Condensed && text.Trim().Length == 0))
             {
                 return;
             }

--- a/Core/Game.cs
+++ b/Core/Game.cs
@@ -3015,7 +3015,7 @@ namespace GenieClient.Genie
                                 {
                                     bool bNewLineStart = text.StartsWith(System.Environment.NewLine);
                                     bool bNewLineEnd = text.EndsWith(System.Environment.NewLine);
-                                    text = sl.SubstituteRegex.Replace(Utility.Trim(text), sl.sReplaceBy.ToString());
+                                    text = sl.SubstituteRegex.Replace(Utility.Trim(text), m_oGlobals.ParseGlobalVars(sl.sReplaceBy).ToString());
                                     if (bNewLineStart == true)
                                     {
                                         text = System.Environment.NewLine + text;

--- a/Core/Game.cs
+++ b/Core/Game.cs
@@ -2497,13 +2497,15 @@ namespace GenieClient.Genie
 
         private Regex m_MonsterRegex = new Regex("<pushBold />([^<]*)<popBold />([^,.]*)", MyRegexOptions.options);
         private Regex m_RoomObjectsRegex = new Regex("<pushBold />([^<]*)<popBold />");
-
+        private static int tagOffset = "<pushBold /><popBold />".Length;
         private void SetRoomObjects(XmlNode oXmlNode)
         {
             m_oGlobals.RoomObjects.Clear();
-            foreach (Match roomObject in m_RoomObjectsRegex.Matches(oXmlNode.InnerXml.Replace(" and ", ", ").Replace(" and <pushBold />", ", <pushBold />")))
+            foreach (Match roomObject in m_RoomObjectsRegex.Matches(oXmlNode.InnerXml))
             {
-                m_oGlobals.RoomObjects.Add(new KeyValuePair<string, string>("creatures", ParseSubstitutions(roomObject.Groups[1].Value)));
+                int position = roomObject.Index - (tagOffset * m_oGlobals.RoomObjects.Count);
+                VolatileHighlight highlight = new VolatileHighlight(ParseSubstitutions(roomObject.Groups[1].Value), "creatures", position);
+                m_oGlobals.RoomObjects.Add(highlight);
             }
         }
         private int CountMonsters(XmlNode oXmlNode)

--- a/Core/Game.cs
+++ b/Core/Game.cs
@@ -790,9 +790,8 @@ namespace GenieClient.Genie
 
                 if (!(sTextBuffer == "\r\n" && hasXML))
                 {
-                    bool argbIsPrompt1 = false;
-                    WindowTarget argoWindowTarget1 = 0;
-                    PrintTextWithParse(sTextBuffer, bIsPrompt: argbIsPrompt1, oWindowTarget: argoWindowTarget1);
+                    bool isRoomOutput = sText.Contains(@"<preset id='roomDesc'>");
+                    PrintTextWithParse(sTextBuffer, default, default, default, default, isRoomOutput);
                 }
                 
                 

--- a/Core/Game.cs
+++ b/Core/Game.cs
@@ -522,6 +522,7 @@ namespace GenieClient.Genie
             string sHTMLBuffer = string.Empty;
             string sTextBuffer = string.Empty;
             string sBoldBuffer = string.Empty;
+            int iBoldIndex = 0;
             char cPreviousChar = Conversions.ToChar("");
             bool bCombatRow = false;
             bool bPromptRow = false;
@@ -592,7 +593,7 @@ namespace GenieClient.Genie
                                             break;
                                     }
                                     sTmp = ParseSubstitutions(sTmp);
-                                    m_oGlobals.VolatileHighlights.Add(new System.Collections.Generic.KeyValuePair<string, string>(presetLabel, sTmp));
+                                    m_oGlobals.VolatileHighlights.Add(new VolatileHighlight(sTmp, presetLabel, 0));
                                     if(presetLabel == "roomdesc")
                                     {
                                         PrintTextWithParse(sTmp, bIsPrompt: false, oWindowTarget: 0);
@@ -602,13 +603,14 @@ namespace GenieClient.Genie
                                 if (buffer.EndsWith(@"<pushBold/>"))
                                 {
                                     sBoldBuffer = string.Empty;
+                                    iBoldIndex = sTextBuffer.Length; //do not subtract 1 because our start index isn't added yet
                                 }
                                 if (buffer.EndsWith(@"<popBold/>"))
                                 {
                                     if (!string.IsNullOrWhiteSpace(sBoldBuffer))
                                     {
                                         sBoldBuffer = ParseSubstitutions(sBoldBuffer);
-                                        m_oGlobals.VolatileHighlights.Add(new System.Collections.Generic.KeyValuePair<string, string>("creatures", sBoldBuffer));
+                                        m_oGlobals.VolatileHighlights.Add(new VolatileHighlight(sBoldBuffer, "creatures", iBoldIndex));
                                     }
                                 }
                                 if (m_bBold)
@@ -765,7 +767,7 @@ namespace GenieClient.Genie
                 else if (!string.IsNullOrWhiteSpace(sBoldBuffer))
                 {
                     sBoldBuffer = ParseSubstitutions(sBoldBuffer);
-                    m_oGlobals.VolatileHighlights.Add(new System.Collections.Generic.KeyValuePair<string, string>("creatures", sBoldBuffer.Trim())); //trim because excessive whitespace seems to be breaking this
+                    m_oGlobals.VolatileHighlights.Add(new VolatileHighlight(sBoldBuffer.Trim(), "creatures", iBoldIndex)); //trim because excessive whitespace seems to be breaking this
                     sBoldBuffer = string.Empty;
                 }
 

--- a/Core/Game.cs
+++ b/Core/Game.cs
@@ -3139,7 +3139,7 @@ namespace GenieClient.Genie
                         m_iConnectAttempts = 0;
                         m_bManualDisconnect = false;
                         m_oReconnectTime = default;
-                        m_oSocket.Send(m_sConnectKey + Constants.vbLf + "/FE:GENIE /VERSION:" + My.MyProject.Application.Info.Version.ToString() + " / P:WIN_UNKNOWN /XML" + Constants.vbLf);    // TEMP
+                        m_oSocket.Send(m_sConnectKey + Constants.vbLf + "FE:WRAYTH /VERSION:1.0.1.22 /P:WIN_UNKNOWN /XML" + Constants.vbLf);    // TEMP
                         string argkey = "connected";
                         string argvalue = m_oSocket.IsConnected ? "1" : "0";
                         m_oGlobals.VariableList.Add(argkey, argvalue, Globals.Variables.VariableType.Reserved);

--- a/Core/LegacyPluginHost.cs
+++ b/Core/LegacyPluginHost.cs
@@ -93,7 +93,8 @@ namespace GenieClient
                 return false;
             string argsText = Utility.GenerateAccountHash(key);
             string premKey = Utility.EncryptString(m_oGlobals.GenieKey, argsText);
-            return m_oGlobals.PluginPremiumKeyList.ContainsKey(premKey);
+            return true;
+            //return m_oGlobals.PluginPremiumKeyList.ContainsKey(premKey); #Was checking Hash and returning true/false. Now always true.
         }
 
         public LegacyPluginHost(Form Form, ref Genie.Globals Globals)

--- a/Forms/Components/ComponentRichTextBox.cs
+++ b/Forms/Components/ComponentRichTextBox.cs
@@ -508,43 +508,46 @@ namespace GenieClient
             }
 
             // Presets and Bold
-            if (m_oParentForm.Globals.VolatileHighlights.Count > 0)
+            foreach (VolatileHighlight highlight in m_oParentForm.Globals.VolatileHighlights.ToArray())
             {
-                foreach (KeyValuePair<string, string> highlight in m_oParentForm.Globals.VolatileHighlights.ToArray())
+                int runningPosition = 0;
+                Regex volatileRegex = new Regex(Regex.Escape(highlight));
+                foreach(string line in m_oRichTextBuffer.Text.Split('\n')) 
                 {
-                    Regex volatileRegex = new Regex(Regex.Escape(highlight.Value));
-                    oMatchCollection = volatileRegex.Matches(m_oRichTextBuffer.Text);
+                    int timestampOffset = 0;
+                    if (m_bTimeStamp)
                     {
-                        foreach (Match oMatch in oMatchCollection)
-                        {
-                            if (m_oParentForm.Globals.PresetList[highlight.Key].bHighlightLine)
-                            {
-                                int indexOfHighlight = m_oRichTextBuffer.Text.IndexOf(highlight.Value);
-                                int lastNewLineIndex = m_oRichTextBuffer.Text.LastIndexOf("\n", indexOfHighlight);
-                                int nextNewLineIndex = m_oRichTextBuffer.Text.IndexOf("\n", indexOfHighlight);
-                                if (lastNewLineIndex == -1) lastNewLineIndex = 0;
-                                if (nextNewLineIndex == -1) nextNewLineIndex = m_oRichTextBuffer.Text.Length;
-                                m_oRichTextBuffer.SelectionStart = lastNewLineIndex >= 0 ? lastNewLineIndex : 0;
-                                m_oRichTextBuffer.SelectionLength = nextNewLineIndex - lastNewLineIndex;
-                            }
-                            else
-                            {
-                                m_oRichTextBuffer.SelectionStart = oMatch.Groups[0].Index;
-                                m_oRichTextBuffer.SelectionLength = oMatch.Groups[0].Length;
-                            }
-                            if (!Operators.ConditionalCompareObjectEqual(m_oParentForm.Globals.PresetList[highlight.Key].FgColor, Color.Transparent, false))
-                            {
-                                m_oRichTextBuffer.SelectionColor = (Color)m_oParentForm.Globals.PresetList[highlight.Key].FgColor;
-                            }
-
-                            if (!Operators.ConditionalCompareObjectEqual(m_oParentForm.Globals.PresetList[highlight.Key].BgColor, Color.Transparent, false))
-                            {
-                                m_oRichTextBuffer.SelectionBackColor = (Color)m_oParentForm.Globals.PresetList[highlight.Key].BgColor;
-                            }
-                        }
+                        timestampOffset += GetTimeString(line).Length;
                     }
+                    if (m_oParentForm.Globals.PresetList[highlight.Preset].bHighlightLine)
+                    {
+                        int indexOfHighlight = m_oRichTextBuffer.Text.IndexOf(highlight);
+                        int lastNewLineIndex = m_oRichTextBuffer.Text.LastIndexOf("\n", indexOfHighlight);
+                        int nextNewLineIndex = m_oRichTextBuffer.Text.IndexOf("\n", indexOfHighlight);
+                        if (lastNewLineIndex == -1) lastNewLineIndex = 0;
+                        if (nextNewLineIndex == -1) nextNewLineIndex = m_oRichTextBuffer.Text.Length;
+                        m_oRichTextBuffer.SelectionStart = lastNewLineIndex >= 0 ? lastNewLineIndex : 0;
+                        m_oRichTextBuffer.SelectionLength = nextNewLineIndex - lastNewLineIndex;
+                    }
+                    else if(line.Length >= highlight.EndIndex + timestampOffset && line.Substring(highlight.StartIndex + timestampOffset, highlight.Length) == highlight)
+                    {
+                        m_oRichTextBuffer.SelectionStart = runningPosition + timestampOffset + highlight.StartIndex;
+                        m_oRichTextBuffer.SelectionLength = highlight.Length;
+                    }
+                    if (!Operators.ConditionalCompareObjectEqual(m_oParentForm.Globals.PresetList[highlight.Preset].FgColor, Color.Transparent, false))
+                    {
+                        m_oRichTextBuffer.SelectionColor = (Color)m_oParentForm.Globals.PresetList[highlight.Preset].FgColor;
+                    }
+
+                    if (!Operators.ConditionalCompareObjectEqual(m_oParentForm.Globals.PresetList[highlight.Preset].BgColor, Color.Transparent, false))
+                    {
+                        m_oRichTextBuffer.SelectionBackColor = (Color)m_oParentForm.Globals.PresetList[highlight.Preset].BgColor;
+                    }
+                    runningPosition += line.Length + 1; //add 1 to account for the \n characters removed by the split
                 }
+                
             }
+            
 
             // Highlight String
             if (!Information.IsNothing(m_oParentForm.Globals.HighlightList.RegexString))

--- a/Forms/Components/ComponentRichTextBox.cs
+++ b/Forms/Components/ComponentRichTextBox.cs
@@ -528,21 +528,31 @@ namespace GenieClient
                         if (nextNewLineIndex == -1) nextNewLineIndex = m_oRichTextBuffer.Text.Length;
                         m_oRichTextBuffer.SelectionStart = lastNewLineIndex >= 0 ? lastNewLineIndex : 0;
                         m_oRichTextBuffer.SelectionLength = nextNewLineIndex - lastNewLineIndex;
+                        if (m_oParentForm.Globals.PresetList[highlight.Preset].FgColor != Color.Transparent)
+                        {
+                            m_oRichTextBuffer.SelectionColor = (Color)m_oParentForm.Globals.PresetList[highlight.Preset].FgColor;
+                        }
+
+                        if (m_oParentForm.Globals.PresetList[highlight.Preset].BgColor != Color.Transparent)
+                        {
+                            m_oRichTextBuffer.SelectionBackColor = (Color)m_oParentForm.Globals.PresetList[highlight.Preset].BgColor;
+                        }
                     }
                     else if(line.Length >= highlight.EndIndex + timestampOffset && line.Substring(highlight.StartIndex + timestampOffset, highlight.Length) == highlight)
                     {
                         m_oRichTextBuffer.SelectionStart = runningPosition + timestampOffset + highlight.StartIndex;
                         m_oRichTextBuffer.SelectionLength = highlight.Length;
-                    }
-                    if (!Operators.ConditionalCompareObjectEqual(m_oParentForm.Globals.PresetList[highlight.Preset].FgColor, Color.Transparent, false))
-                    {
-                        m_oRichTextBuffer.SelectionColor = (Color)m_oParentForm.Globals.PresetList[highlight.Preset].FgColor;
+                        if (m_oParentForm.Globals.PresetList[highlight.Preset].FgColor != Color.Transparent)
+                        {
+                            m_oRichTextBuffer.SelectionColor = (Color)m_oParentForm.Globals.PresetList[highlight.Preset].FgColor;
+                        }
+
+                        if (m_oParentForm.Globals.PresetList[highlight.Preset].BgColor != Color.Transparent)
+                        {
+                            m_oRichTextBuffer.SelectionBackColor = (Color)m_oParentForm.Globals.PresetList[highlight.Preset].BgColor;
+                        }
                     }
 
-                    if (!Operators.ConditionalCompareObjectEqual(m_oParentForm.Globals.PresetList[highlight.Preset].BgColor, Color.Transparent, false))
-                    {
-                        m_oRichTextBuffer.SelectionBackColor = (Color)m_oParentForm.Globals.PresetList[highlight.Preset].BgColor;
-                    }
                     runningPosition += line.Length + 1; //add 1 to account for the \n characters removed by the split
                 }
                 

--- a/Forms/FormMain.Designer.cs
+++ b/Forms/FormMain.Designer.cs
@@ -100,6 +100,7 @@ namespace GenieClient
             this._WindowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this._ScriptToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this._ScriptExplorerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.updateScriptsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this._ToolStripSeparator11 = new System.Windows.Forms.ToolStripSeparator();
             this._ListAllScriptsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this._TraceAllScriptsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -768,6 +769,7 @@ namespace GenieClient
             // 
             this._ScriptToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this._ScriptExplorerToolStripMenuItem,
+            this.updateScriptsToolStripMenuItem,
             this._ToolStripSeparator11,
             this._ListAllScriptsToolStripMenuItem,
             this._TraceAllScriptsToolStripMenuItem,
@@ -783,58 +785,65 @@ namespace GenieClient
             // _ScriptExplorerToolStripMenuItem
             // 
             this._ScriptExplorerToolStripMenuItem.Name = "_ScriptExplorerToolStripMenuItem";
-            this._ScriptExplorerToolStripMenuItem.Size = new System.Drawing.Size(177, 22);
+            this._ScriptExplorerToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this._ScriptExplorerToolStripMenuItem.Text = "Script &Explorer...";
             this._ScriptExplorerToolStripMenuItem.Click += new System.EventHandler(this.ScriptExplorerToolStripMenuItem_Click);
+            // 
+            // updateScriptsToolStripMenuItem
+            // 
+            this.updateScriptsToolStripMenuItem.Name = "updateScriptsToolStripMenuItem";
+            this.updateScriptsToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.updateScriptsToolStripMenuItem.Text = "&Update Scripts";
+            this.updateScriptsToolStripMenuItem.Click += new System.EventHandler(this.updateScriptsToolStripMenuItem_Click);
             // 
             // _ToolStripSeparator11
             // 
             this._ToolStripSeparator11.Name = "_ToolStripSeparator11";
-            this._ToolStripSeparator11.Size = new System.Drawing.Size(174, 6);
+            this._ToolStripSeparator11.Size = new System.Drawing.Size(177, 6);
             // 
             // _ListAllScriptsToolStripMenuItem
             // 
             this._ListAllScriptsToolStripMenuItem.Name = "_ListAllScriptsToolStripMenuItem";
-            this._ListAllScriptsToolStripMenuItem.Size = new System.Drawing.Size(177, 22);
+            this._ListAllScriptsToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this._ListAllScriptsToolStripMenuItem.Text = "&Show Active Scripts";
             this._ListAllScriptsToolStripMenuItem.Click += new System.EventHandler(this.ListAllScriptsToolStripMenuItem_Click);
             // 
             // _TraceAllScriptsToolStripMenuItem
             // 
             this._TraceAllScriptsToolStripMenuItem.Name = "_TraceAllScriptsToolStripMenuItem";
-            this._TraceAllScriptsToolStripMenuItem.Size = new System.Drawing.Size(177, 22);
+            this._TraceAllScriptsToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this._TraceAllScriptsToolStripMenuItem.Text = "&Trace Active Scripts";
             this._TraceAllScriptsToolStripMenuItem.Click += new System.EventHandler(this.TraceAllScriptsToolStripMenuItem_Click);
             // 
             // _ToolStripSeparator9
             // 
             this._ToolStripSeparator9.Name = "_ToolStripSeparator9";
-            this._ToolStripSeparator9.Size = new System.Drawing.Size(174, 6);
+            this._ToolStripSeparator9.Size = new System.Drawing.Size(177, 6);
             // 
             // _PauseAllScriptsToolStripMenuItem
             // 
             this._PauseAllScriptsToolStripMenuItem.Name = "_PauseAllScriptsToolStripMenuItem";
-            this._PauseAllScriptsToolStripMenuItem.Size = new System.Drawing.Size(177, 22);
+            this._PauseAllScriptsToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this._PauseAllScriptsToolStripMenuItem.Text = "&Pause All Scripts";
             this._PauseAllScriptsToolStripMenuItem.Click += new System.EventHandler(this.PauseAllScriptsToolStripMenuItem_Click);
             // 
             // _ResumeAllScriptsToolStripMenuItem
             // 
             this._ResumeAllScriptsToolStripMenuItem.Name = "_ResumeAllScriptsToolStripMenuItem";
-            this._ResumeAllScriptsToolStripMenuItem.Size = new System.Drawing.Size(177, 22);
+            this._ResumeAllScriptsToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this._ResumeAllScriptsToolStripMenuItem.Text = "&Resume All Scripts";
             this._ResumeAllScriptsToolStripMenuItem.Click += new System.EventHandler(this.ResumeAllScriptsToolStripMenuItem_Click);
             // 
             // _ToolStripMenuItem3
             // 
             this._ToolStripMenuItem3.Name = "_ToolStripMenuItem3";
-            this._ToolStripMenuItem3.Size = new System.Drawing.Size(174, 6);
+            this._ToolStripMenuItem3.Size = new System.Drawing.Size(177, 6);
             // 
             // _AbortAllScriptsToolStripMenuItem
             // 
             this._AbortAllScriptsToolStripMenuItem.Name = "_AbortAllScriptsToolStripMenuItem";
             this._AbortAllScriptsToolStripMenuItem.ShortcutKeyDisplayString = "";
-            this._AbortAllScriptsToolStripMenuItem.Size = new System.Drawing.Size(177, 22);
+            this._AbortAllScriptsToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this._AbortAllScriptsToolStripMenuItem.Text = "&Abort All Scripts";
             this._AbortAllScriptsToolStripMenuItem.Click += new System.EventHandler(this.AbortAllScriptsToolStripMenuItem_Click);
             // 
@@ -4194,6 +4203,7 @@ namespace GenieClient
         private ToolStripMenuItem loadTestClientToolStripMenuItem;
         private ToolStripMenuItem updateMapsToolStripMenuItem;
         private ToolStripMenuItem updatePluginsToolStripMenuItem;
+        private ToolStripMenuItem updateScriptsToolStripMenuItem;
 
         internal ToolStripMenuItem SaveSizedDefaultLayoutToolStripMenuItem
         {

--- a/Forms/FormMain.cs
+++ b/Forms/FormMain.cs
@@ -9,6 +9,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using Microsoft.VisualBasic;
 using Microsoft.VisualBasic.CompilerServices;
@@ -1902,7 +1903,7 @@ namespace GenieClient
             Application.DoEvents();
             int I = LoadPlugins();
             Application.DoEvents();
-            UpdateOnStartup();
+            Parallel.Invoke(UpdateOnStartup);
             Application.DoEvents();
 
             m_oOutputMain.RichTextBoxOutput.EndTextUpdate();

--- a/Forms/FormMain.cs
+++ b/Forms/FormMain.cs
@@ -7917,35 +7917,38 @@ namespace GenieClient
 
         private void checkForUpdatesToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (Updater.ClientIsCurrent)
+            Parallel.Invoke(() =>
             {
-                AddText("You have the latest version of Genie.\r\n", m_oGlobals.PresetList["scriptecho"].FgColor, m_oGlobals.PresetList["scriptecho"].BgColor);
-            }
-            else
-            {
-                AddText("An Update is Available.\r\n", m_oGlobals.PresetList["scriptecho"].FgColor, m_oGlobals.PresetList["scriptecho"].BgColor, Genie.Game.WindowTarget.Main);
-                DialogResult response = MessageBox.Show("An Update is Available. Would you like to update?", "Rub the Bottle?", MessageBoxButtons.YesNoCancel);
-                if (response == DialogResult.Yes)
+                if (Updater.ClientIsCurrent)
                 {
-                    if (m_oGame.IsConnectedToGame)
+                    AddText("You have the latest version of Genie.\r\n", m_oGlobals.PresetList["scriptecho"].FgColor, m_oGlobals.PresetList["scriptecho"].BgColor);
+                }
+                else
+                {
+                    AddText("An Update is Available.\r\n", m_oGlobals.PresetList["scriptecho"].FgColor, m_oGlobals.PresetList["scriptecho"].BgColor, Genie.Game.WindowTarget.Main);
+                    DialogResult response = MessageBox.Show("An Update is Available. Would you like to update?", "Rub the Bottle?", MessageBoxButtons.YesNoCancel);
+                    if (response == DialogResult.Yes)
                     {
-                        response = MessageBox.Show("Genie will close and this will disconnect you from the game.", "Close Genie?", MessageBoxButtons.YesNoCancel);
-                        if(response == DialogResult.Yes)
+                        if (m_oGame.IsConnectedToGame)
+                        {
+                            response = MessageBox.Show("Genie will close and this will disconnect you from the game.", "Close Genie?", MessageBoxButtons.YesNoCancel);
+                            if (response == DialogResult.Yes)
+                            {
+                                AddText("Exiting Genie to Update.", m_oGlobals.PresetList["scriptecho"].FgColor, m_oGlobals.PresetList["scriptecho"].BgColor, Genie.Game.WindowTarget.Main);
+                                Updater.RunUpdate();
+                                m_oGame.Disconnect(true);
+                                System.Windows.Forms.Application.Exit();
+                            }
+                        }
+                        else
                         {
                             AddText("Exiting Genie to Update.", m_oGlobals.PresetList["scriptecho"].FgColor, m_oGlobals.PresetList["scriptecho"].BgColor, Genie.Game.WindowTarget.Main);
                             Updater.RunUpdate();
-                            m_oGame.Disconnect(true);
                             System.Windows.Forms.Application.Exit();
                         }
                     }
-                    else
-                    {
-                        AddText("Exiting Genie to Update.", m_oGlobals.PresetList["scriptecho"].FgColor, m_oGlobals.PresetList["scriptecho"].BgColor, Genie.Game.WindowTarget.Main);
-                        Updater.RunUpdate();
-                        System.Windows.Forms.Application.Exit();
-                    }
                 }
-            }
+            });
         }
 
         private void forceUpdateToolStripMenuItem_Click(object sender, EventArgs e)
@@ -8005,15 +8008,18 @@ namespace GenieClient
             DialogResult response = MessageBox.Show("This may take a moment. Update Maps?", "Update Maps?", MessageBoxButtons.YesNoCancel);
             if (response == DialogResult.Yes)
             {
-                AddText($"Updating Maps in {m_oGlobals.Config.MapDir}\r\n", m_oGlobals.PresetList["scriptecho"].FgColor, m_oGlobals.PresetList["scriptecho"].BgColor, Genie.Game.WindowTarget.Main);
-                if (Updater.UpdateMaps(m_oGlobals.Config.MapDir))
+                Parallel.Invoke(() =>
                 {
-                    AddText("Maps Updated.\r\n", m_oGlobals.PresetList["scriptecho"].FgColor, m_oGlobals.PresetList["scriptecho"].BgColor, Genie.Game.WindowTarget.Main); 
-                }
-                else
-                {
-                    AddText("Something went wrong.\r\n", m_oGlobals.PresetList["scriptecho"].FgColor, m_oGlobals.PresetList["scriptecho"].BgColor, Genie.Game.WindowTarget.Main);
-                }
+                    AddText($"Updating Maps in {m_oGlobals.Config.MapDir}\r\n", m_oGlobals.PresetList["scriptecho"].FgColor, m_oGlobals.PresetList["scriptecho"].BgColor, Genie.Game.WindowTarget.Main);
+                    if (Updater.UpdateMaps(m_oGlobals.Config.MapDir))
+                    {
+                        AddText("Maps Updated.\r\n", m_oGlobals.PresetList["scriptecho"].FgColor, m_oGlobals.PresetList["scriptecho"].BgColor, Genie.Game.WindowTarget.Main);
+                    }
+                    else
+                    {
+                        AddText("Something went wrong.\r\n", m_oGlobals.PresetList["scriptecho"].FgColor, m_oGlobals.PresetList["scriptecho"].BgColor, Genie.Game.WindowTarget.Main);
+                    }
+                });
             }
         }
 
@@ -8022,16 +8028,19 @@ namespace GenieClient
             DialogResult response = MessageBox.Show("This may take a moment. Update Plugins?\r\nNote: This will only update plugins from the Genie 4 Plugins folder..", "Update Maps?", MessageBoxButtons.YesNoCancel);
             if (response == DialogResult.Yes)
             {
-                AddText($"Updating Plugins in {m_oGlobals.Config.PluginDir}\r\n", m_oGlobals.PresetList["scriptecho"].FgColor, m_oGlobals.PresetList["scriptecho"].BgColor, Genie.Game.WindowTarget.Main);
-                if (Updater.UpdatePlugins(m_oGlobals.Config.PluginDir))
+                Parallel.Invoke(() =>
                 {
-                    AddText("Plugins Updated.\r\n", m_oGlobals.PresetList["scriptecho"].FgColor, m_oGlobals.PresetList["scriptecho"].BgColor, Genie.Game.WindowTarget.Main);
-                    FormPlugin_ReloadPlugins();
-                }
-                else
-                {
-                    AddText("Something went wrong.\r\n", m_oGlobals.PresetList["scriptecho"].FgColor, m_oGlobals.PresetList["scriptecho"].BgColor, Genie.Game.WindowTarget.Main);
-                }
+                    AddText($"Updating Plugins in {m_oGlobals.Config.PluginDir}\r\n", m_oGlobals.PresetList["scriptecho"].FgColor, m_oGlobals.PresetList["scriptecho"].BgColor, Genie.Game.WindowTarget.Main);
+                    if (Updater.UpdatePlugins(m_oGlobals.Config.PluginDir))
+                    {
+                        AddText("Plugins Updated.\r\n", m_oGlobals.PresetList["scriptecho"].FgColor, m_oGlobals.PresetList["scriptecho"].BgColor, Genie.Game.WindowTarget.Main);
+                        FormPlugin_ReloadPlugins();
+                    }
+                    else
+                    {
+                        AddText("Something went wrong.\r\n", m_oGlobals.PresetList["scriptecho"].FgColor, m_oGlobals.PresetList["scriptecho"].BgColor, Genie.Game.WindowTarget.Main);
+                    }
+                });
             }
         }
     }

--- a/Forms/FormMain.cs
+++ b/Forms/FormMain.cs
@@ -8025,7 +8025,7 @@ namespace GenieClient
 
         private void updatePluginsToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            DialogResult response = MessageBox.Show("This may take a moment. Update Plugins?\r\nNote: This will only update plugins from the Genie 4 Plugins folder..", "Update Maps?", MessageBoxButtons.YesNoCancel);
+            DialogResult response = MessageBox.Show("This may take a moment. Update Plugins?\r\nNote: This will only update plugins from the Genie 4 Plugins folder..", "Update Plugins?", MessageBoxButtons.YesNoCancel);
             if (response == DialogResult.Yes)
             {
                 Parallel.Invoke(() =>
@@ -8035,6 +8035,31 @@ namespace GenieClient
                     {
                         AddText("Plugins Updated.\r\n", m_oGlobals.PresetList["scriptecho"].FgColor, m_oGlobals.PresetList["scriptecho"].BgColor, Genie.Game.WindowTarget.Main);
                         FormPlugin_ReloadPlugins();
+                    }
+                    else
+                    {
+                        AddText("Something went wrong.\r\n", m_oGlobals.PresetList["scriptecho"].FgColor, m_oGlobals.PresetList["scriptecho"].BgColor, Genie.Game.WindowTarget.Main);
+                    }
+                });
+            }
+        }
+
+        private void updateScriptsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (!m_oGlobals.Config.ScriptRepo.EndsWith(".zip"))
+            {
+                MessageBox.Show("You do not have a repository configured properly." + Environment.NewLine + "Please use \"#config scriptrepo {address of a zip file}\" to configure." + Environment.NewLine + "The URI must be a zip file.");
+                return; 
+            }
+            DialogResult response = MessageBox.Show($"This may take a moment. Update Scripts?\r\nRepo: {m_oGlobals.Config.ScriptRepo}", "Update Scripts?", MessageBoxButtons.YesNoCancel);
+            if (response == DialogResult.Yes)
+            {
+                Parallel.Invoke(() =>
+                {
+                    AddText($"Updating Scripts in {m_oGlobals.Config.ScriptDir}\r\n", m_oGlobals.PresetList["scriptecho"].FgColor, m_oGlobals.PresetList["scriptecho"].BgColor, Genie.Game.WindowTarget.Main);
+                    if (Updater.UpdateScripts(m_oGlobals.Config.ScriptDir, m_oGlobals.Config.ScriptRepo))
+                    {
+                        AddText("Scripts Updated.\r\n", m_oGlobals.PresetList["scriptecho"].FgColor, m_oGlobals.PresetList["scriptecho"].BgColor, Genie.Game.WindowTarget.Main);
                     }
                     else
                     {

--- a/Forms/FormMain.cs
+++ b/Forms/FormMain.cs
@@ -456,6 +456,7 @@ namespace GenieClient
                 {
                     _m_oAutoMapper.EventEchoText -= Plugin_EventEchoText;
                     _m_oAutoMapper.EventSendText -= Plugin_EventSendText;
+                    _m_oAutoMapper.EventParseText -= ClassCommand_ParseText;
                     _m_oAutoMapper.EventVariableChanged -= PluginHost_EventVariableChanged;
                 }
 
@@ -464,6 +465,7 @@ namespace GenieClient
                 {
                     _m_oAutoMapper.EventEchoText += Plugin_EventEchoText;
                     _m_oAutoMapper.EventSendText += Plugin_EventSendText;
+                    _m_oAutoMapper.EventParseText += ClassCommand_ParseText;
                     _m_oAutoMapper.EventVariableChanged += PluginHost_EventVariableChanged;
                 }
             }

--- a/Lists/Config.cs
+++ b/Lists/Config.cs
@@ -66,6 +66,8 @@ namespace GenieClient.Genie
         public string ConnectScript { get; set; } = string.Empty;
         public string ScriptExtension { get; set; } = "cmd";
 
+        public string ScriptRepo { get; set; } = string.Empty;
+         
         public string ScriptDir
         {
             get
@@ -365,6 +367,7 @@ namespace GenieClient.Genie
                 oStreamWriter.WriteLine("#config {maxgosubdepth} {" + iMaxGoSubDepth + "}");
                 oStreamWriter.WriteLine("#config {ignorescriptwarnings} {" + bIgnoreScriptWarnings + "}");
                 oStreamWriter.WriteLine("#config {roundtimeoffset} {" + dRTOffset + "}");
+                oStreamWriter.WriteLine("#config {scriptrepo} {" + ScriptRepo + "}");
                 oStreamWriter.WriteLine("#config {scriptdir} {" + sScriptDir + "}");
                 oStreamWriter.WriteLine("#config {mapdir} {" + sMapDir + "}");
                 oStreamWriter.WriteLine("#config {plugindir} {" + sPluginDir + "}");
@@ -769,6 +772,13 @@ namespace GenieClient.Genie
 
                                 messages.Add(LocalDirectory.ValidateDirectory(sValue));
                                 ScriptDir = sValue;
+                                break;
+                            }
+                        
+                        case "scriptrepo":
+                            {
+
+                                ScriptRepo = sValue;
                                 break;
                             }
 

--- a/Lists/Globals.cs
+++ b/Lists/Globals.cs
@@ -488,23 +488,23 @@ namespace GenieClient.Genie
 
             public void SetDefaultPresets()
             {
-                Add("roomname", "Yellow,DarkBlue");
-                Add("roomdesc", "Silver");
-                Add("creatures", "Cyan");
-                Add("speech", "Yellow");
-                Add("whispers", "Magenta");
-                Add("thoughts", "Cyan");
-                Add("roundtime", "MediumBlue");
-                Add("health", "Maroon");
-                Add("mana", "Navy");
-                Add("stamina", "Green");
-                Add("spirit", "Purple");
+                Add("castbar", "Magenta");
                 Add("concentration", "Navy");
+                Add("creatures", "Cyan");
+                Add("familiar", "PaleGreen");
+                Add("health", "Maroon");
                 Add("inputuser", "Yellow");
                 Add("inputother", "GreenYellow");
+                Add("mana", "Navy");
+                Add("roomdesc", "Silver");
+                Add("roomname", "Yellow,DarkBlue");
+                Add("roundtime", "MediumBlue");
                 Add("scriptecho", "Cyan");
-                Add("familiar", "PaleGreen");
-                Add("castbar", "Magenta");
+                Add("speech", "Yellow");
+                Add("spirit", "Purple");
+                Add("stamina", "Green");
+                Add("thoughts", "Cyan");
+                Add("whispers", "Magenta");
             }
 
             public Presets()

--- a/Lists/Globals.cs
+++ b/Lists/Globals.cs
@@ -115,7 +115,7 @@ namespace GenieClient.Genie
 
         public List<string> MonsterList = new List<string>();
         public List<VolatileHighlight> VolatileHighlights = new List<VolatileHighlight>();
-        public List<KeyValuePair<string, string>> RoomObjects = new List<KeyValuePair<string, string>>();
+        public List<VolatileHighlight> RoomObjects = new List<VolatileHighlight>();
         public Regex MonsterListRegEx;
 
         public void UpdateMonsterListRegEx()

--- a/Lists/Globals.cs
+++ b/Lists/Globals.cs
@@ -114,7 +114,7 @@ namespace GenieClient.Genie
         }
 
         public List<string> MonsterList = new List<string>();
-        public List<KeyValuePair<string, string>> VolatileHighlights = new List<KeyValuePair<string, string>>();
+        public List<VolatileHighlight> VolatileHighlights = new List<VolatileHighlight>();
         public List<KeyValuePair<string, string>> RoomObjects = new List<KeyValuePair<string, string>>();
         public Regex MonsterListRegEx;
 

--- a/Lists/VolatileHighlight.cs
+++ b/Lists/VolatileHighlight.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GenieClient.Genie
+{
+    public class VolatileHighlight
+    {
+        public string Text { get; set; }
+        public string Preset { get; set; }
+        public int StartIndex { get; set; }
+        public int Length { get { return Text.Length; } }
+        public int EndIndex { get { return StartIndex + Length; } }
+        public VolatileHighlight(string HighlightText, string PresetLabel, int StartPosition)
+        {
+            Text = HighlightText;
+            Preset = PresetLabel;
+            StartIndex = StartPosition;
+        }
+        public static implicit operator string(VolatileHighlight highlight)
+        {
+            return highlight.Text;
+        }
+    }
+}

--- a/Mapper/AutoMapper.cs
+++ b/Mapper/AutoMapper.cs
@@ -33,6 +33,10 @@ namespace GenieClient.Mapper
 
         public delegate void EventSendTextEventHandler(string sText, string sSource);
 
+        public event EventParseTextEventHandler EventParseText;
+
+        public delegate void EventParseTextEventHandler(string sText);
+
         public event EventVariableChangedEventHandler EventVariableChanged;
 
         public delegate void EventVariableChangedEventHandler(string sVariable);
@@ -1215,21 +1219,21 @@ namespace GenieClient.Mapper
                                     {
                                         EchoText("#goto " + sArg, true);
                                         set_GlobalVariable("destination", iNodeID.ToString());
-                                        SendText("#parse DESTINATION FOUND");
+                                        ParseText("DESTINATION FOUND", true);
                                         WalkToNode(n);
                                     }
                                     else
                                     {
                                         EchoText("[" + Name + "] Destination ID #" + iNodeID.ToString() + " not found - your current location is unknown.", true);
                                         set_GlobalVariable("destination", "0");
-                                        SendText("#parse DESTINATION NOT FOUND");
+                                        ParseText("DESTINATION NOT FOUND", true);
                                     }
                                 }
                                 else
                                 {
                                     EchoText("[" + Name + "] Destination ID \"" + sArg + "\" not found.", true);
                                     set_GlobalVariable("destination", "0");
-                                    SendText("#parse DESTINATION NOT FOUND");
+                                    ParseText("DESTINATION NOT FOUND", true);
                                 }
                             }
                             else
@@ -1331,13 +1335,13 @@ namespace GenieClient.Mapper
                             {
                                 // Show all labels in map zone (doesn't matter if player is located or not)
                                 EchoText("[" + Name + "] Listing current zone labels:", true);
-                                SendText("#parse [" + Name + "] Listing current zone labels:");
+                                ParseText("[" + Name + "] Listing current zone labels:", true);
                                 foreach (Node n in m_Nodes)
                                 {
                                     if (n.Note.Length > 0)
                                     {
                                         EchoText(Constants.vbTab + n.Note + " (" + n.ID.ToString() + ")", true);
-                                        SendText("#parse " + Constants.vbTab + n.Note + " (" + n.ID.ToString() + ")");
+                                        ParseText("" + Constants.vbTab + n.Note + " (" + n.ID.ToString() + ")", true);
                                     }
                                 }
                                 break;
@@ -1620,7 +1624,7 @@ namespace GenieClient.Mapper
                 if (m_Nodes.PathText.Length > 0)
                 {
                     EchoText("[" + Name + "] mapperpath: " + m_Nodes.PathVariableText, true);
-                    SendText("#parse [" + Name + "] mapperpath: " + m_Nodes.PathVariableText);
+                    ParseText("[" + Name + "] mapperpath: " + m_Nodes.PathVariableText, true);
                     set_GlobalVariable("mapperpath", m_Nodes.PathVariableText);
                 }
             }
@@ -1957,7 +1961,7 @@ namespace GenieClient.Mapper
         private void GrapForm_ClickNode(string zoneid, int nodeid)
         {
             set_GlobalVariable("destination", nodeid.ToString());
-            SendText(string.Format("#parse MAPCLICK {0} {1}", zoneid, nodeid));
+            ParseText(string.Format("MAPCLICK {0} {1}", zoneid, nodeid), true);
         }
 
         private void GraphForm_ZoneIDChange(string zoneid)
@@ -2012,6 +2016,11 @@ namespace GenieClient.Mapper
         public void SendText(string Text)
         {
             EventSendText?.Invoke(Text, "AutoMapper");
+
+        }
+        public void ParseText(string Text, bool automapper)
+        {
+            EventParseText?.Invoke(Text);
         }
 
         public string get_GlobalVariable(string Var)

--- a/Mapper/AutoMapper.cs
+++ b/Mapper/AutoMapper.cs
@@ -243,7 +243,8 @@ namespace GenieClient.Mapper
                         if ((dif.Extension.ToLower() ?? "") == ".xml")
                     {
                         xdoc = new XmlDocument();
-                        xdoc.Load(dif.FullName);
+                        
+                        xdoc.Load(new StreamReader(dif.FullName,true));
                         xnlist = xdoc.SelectNodes("zone/node");
                         foreach (XmlNode xn in xnlist)
                         {
@@ -300,7 +301,7 @@ namespace GenieClient.Mapper
                 if ((dif.Extension.ToLower() ?? "") == ".xml")
                 {
                     xdoc = new XmlDocument();
-                    xdoc.Load(dif.FullName);
+                    xdoc.Load(new StreamReader(dif.FullName, true));
                     xnlist = xdoc.SelectNodes("zone/node");
                     foreach (XmlNode xn in xnlist)
                     {

--- a/Mapper/MapForm.cs
+++ b/Mapper/MapForm.cs
@@ -536,7 +536,7 @@ namespace GenieClient.Mapper
                 }
 
                 xdoc = new XmlDocument();
-                xdoc.Load(sPath);
+                xdoc.Load(new StreamReader(sPath, true));
                 var z = new Zone();
                 var xZone = xdoc.SelectSingleNode("zone");
                 if (!Information.IsNothing(xZone))
@@ -618,7 +618,7 @@ namespace GenieClient.Mapper
                     return false;
                 m_CurrentMapFile = sPath;
                 xdoc = new XmlDocument();
-                xdoc.Load(sPath);
+                xdoc.Load(new StreamReader(sPath, true));
                 var xZone = xdoc.SelectSingleNode("zone");
                 if (!Information.IsNothing(xZone))
                 {

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // <Assembly: AssemblyVersion("1.0.*")> 
 
-[assembly: AssemblyVersion("4.0.2.4")]
-[assembly: AssemblyFileVersion("4.0.2.4")]
+[assembly: AssemblyVersion("4.0.2.404")]
+[assembly: AssemblyFileVersion("4.0.2.404")]

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // <Assembly: AssemblyVersion("1.0.*")> 
 
-[assembly: AssemblyVersion("4.0.2.406")]
-[assembly: AssemblyFileVersion("4.0.2.406")]
+[assembly: AssemblyVersion("4.0.2.409")]
+[assembly: AssemblyFileVersion("4.0.2.409")] //in your coffee maker

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // <Assembly: AssemblyVersion("1.0.*")> 
 
-[assembly: AssemblyVersion("4.0.2.404")]
-[assembly: AssemblyFileVersion("4.0.2.404")]
+[assembly: AssemblyVersion("4.0.2.406")]
+[assembly: AssemblyFileVersion("4.0.2.406")]

--- a/Script/Eval.cs
+++ b/Script/Eval.cs
@@ -1086,15 +1086,56 @@ namespace GenieClient.Genie.Script
                     {
                         if (args.Count == 3)
                         {
-                            ((Sections)oSections[iStart]).sBlock = ((Sections)args[0]).sBlock.Substring(Conversions.ToInteger(((Sections)args[1]).sBlock), Conversions.ToInteger(((Sections)args[2]).sBlock)).ToString();
-                            ((Sections)oSections[iStart]).BlockType = ParseType.StringType; // Result
-                            ((Sections)oSections[iStart]).bParsed = false;
+                            int stringLength = ((Sections)args[0]).sBlock.Length;                   
+                            int startPosition = Conversions.ToInteger(((Sections)args[1]).sBlock);   
+                            int substringLength = Conversions.ToInteger(((Sections)args[2]).sBlock);   
+                            if (substringLength < 0)
+                            {
+                                //This allows for negative substrings lengths to read starting before the start index
+                                //however, we cannot actually go negative on our substring call so 
+                                if (startPosition + substringLength >= 0)
+                                {
+                                    //if the negative length is not below 0 simply set our new start there and 
+                                    //and set the length to its absolute value
+                                    startPosition = startPosition + substringLength;
+                                    substringLength = System.Math.Abs(substringLength);
+                                }
+                                else 
+                                {   
+                                    //the new startPosition would be less than 0 so set it to zero
+                                    startPosition = 0;
+                                    //and read the remainder of the length, which is conveniently the start position
+                                    substringLength = Conversions.ToInteger(((Sections)args[1]).sBlock);
+                                }
+                            }
+                            
+                            if (startPosition < 0) startPosition = 0; //prevent negative start or end positions
+                            if (substringLength < 0) substringLength = 0; //in the case we got a negative length and negative start position this can be negative here
+
+                            if (startPosition + substringLength > stringLength)
+                            {   //If the start position + substringLength are greater than the size of the string, just read to the end
+                                ((Sections)oSections[iStart]).sBlock = ((Sections)args[0]).sBlock.Substring(startPosition).ToString();
+                                ((Sections)oSections[iStart]).BlockType = ParseType.StringType; // Result
+                                ((Sections)oSections[iStart]).bParsed = false;
+                            }
+                            else
+                            {   //the full substring is within the size of the string
+                                ((Sections)oSections[iStart]).sBlock = ((Sections)args[0]).sBlock.Substring(startPosition, substringLength).ToString();
+                                ((Sections)oSections[iStart]).BlockType = ParseType.StringType; // Result
+                                ((Sections)oSections[iStart]).bParsed = false;
+                            }
                         }
                         else if (args.Count == 2)
                         {
-                            ((Sections)oSections[iStart]).sBlock = ((Sections)args[0]).sBlock.Substring(Conversions.ToInteger(((Sections)args[1]).sBlock)).ToString();
-                            ((Sections)oSections[iStart]).BlockType = ParseType.StringType; // Result
-                            ((Sections)oSections[iStart]).bParsed = false;
+                            int stringLength = ((Sections)args[0]).sBlock.Length;                   
+                            int startPosition = Conversions.ToInteger(((Sections)args[1]).sBlock);   
+                            if (startPosition <= stringLength && startPosition >= 0)                                  
+                            {
+                                //Will only evalutate if starting position is within supplied string
+                                ((Sections)oSections[iStart]).sBlock = ((Sections)args[0]).sBlock.Substring(startPosition).ToString();
+                                ((Sections)oSections[iStart]).BlockType = ParseType.StringType; // Result
+                                ((Sections)oSections[iStart]).bParsed = false;
+                            }
                         }
 
                         break;

--- a/Script/Script.cs
+++ b/Script/Script.cs
@@ -2510,8 +2510,6 @@ namespace GenieClient
                             // Skip "block"
                             m_oCurrentLine.SkipBlock = true;
                         }
-
-                        m_oCurrentLine.BlockValue = CurrentLine.BlockState.noeval;
                         break;
                     }
 

--- a/Utility/Updater.cs
+++ b/Utility/Updater.cs
@@ -81,7 +81,7 @@ namespace GenieClient
 
         public static void UpdateUpdater()
         {
-            if (UpdaterIsCurrent) return;
+            if (1 == 1) return;
             client.DefaultRequestHeaders.Accept.Clear();
             client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github.v3+json"));
             client.DefaultRequestHeaders.Add("User-Agent", "Genie Client Updater");
@@ -114,13 +114,18 @@ namespace GenieClient
         public static bool UpdateMaps(string mapdir)
         {
             UpdateUpdater();
-            return Utility.ExecuteProcess($@"{Environment.CurrentDirectory}\{UpdaterFilename}", $"--a --m|\"{mapdir}\"", true);
+            return Utility.ExecuteProcess($@"{Environment.CurrentDirectory}\{UpdaterFilename}", $"--background --maps|\"{mapdir}\"", true);
         }
 
         public static bool UpdatePlugins(string plugindir)
         {
             UpdateUpdater();
-            return Utility.ExecuteProcess($@"{Environment.CurrentDirectory}\{UpdaterFilename}", $"--a --p|\"{plugindir}\"", true);
+            return Utility.ExecuteProcess($@"{Environment.CurrentDirectory}\{UpdaterFilename}", $"--background --plugins|\"{plugindir}\"", true);
+        }
+        public static bool UpdateScripts(string scriptdir, string scriptrepo)
+        {
+            UpdateUpdater();
+            return Utility.ExecuteProcess($@"{Environment.CurrentDirectory}\{UpdaterFilename}", $"--background --scripts|\"{scriptdir}\"|\"{scriptrepo}\"", true);
         }
         public static void ForceUpdate()
         {


### PR DESCRIPTION
 - Added new #scriptrepo config. You can set this to a URL which must be a zip file, and use the Update Scripts button on the scripts menu to load the Zip to your #scriptdir
 - Checking for updates and updating maps/plugins no longer freezes Genie for the duration of the update.
 - Fixed if evaluations not properly skipping past remaining else/elseif statements in their block (#109)
 - Forced Linebreaks in Room Output where appropriate when using Condensed Mode (#103)
 - Removed Regex Matching for Bolded Room Objects, now using same logic as VolatileHighlights for RoomObjects (#116)
 - Updated Mapper to infer encoding from byte order instead of trusting the document's encoding header
 - Fixed instances where Volatile Highlights would apply color to non-matching text
 - Updated Automapper to infer coding when loading a map instead of trusting the file to self-identify its encoding
 - Expanded the Highlight command (#111)
 - Removed sub parsing during preset parsing (#105)
 - Fixed an error causing bold to apply to every instance of a string instead of the specified bolded string (#110)
 - Fixed Substring Evaluation to prevent hard crashes (#108)
 - Added negative length handling to Substring Eval (#108)
 - Added Parsing Globals in Substitutes (#108)
 - Removed Key Check for Legacy Premium Plugins (#108)
 - Set FE string to impersonate Wrayth due to client-based restrictions on commands and xml
 - Prevented printing of lines which are only XML and /r/n (#104)