### PR TITLE
removed 3 digit limit on roomids for #goto

### DIFF
--- a/Mapper/AutoMapper.cs
+++ b/Mapper/AutoMapper.cs
@@ -1190,14 +1190,6 @@ namespace GenieClient.Mapper
                             if (sArg.Length > 0)
                             {
                                 int iNodeID = 0;
-                                if (sArg.Length > 3)
-                                {
-                                // Other zone
-                                // - Find the destination map
-                                // - Find what path it needs to take trough the different zones
-                                // Integer.TryParse(sArg.Substring(0, 3), iNodeID)
-                                }
-                                else
                                 {
                                     int.TryParse(sArg, out iNodeID);
                                 }


### PR DESCRIPTION
whatever reason conny had for restricting this is unknown to me, so I just removed the commented out lines and allowed for goto to process IDs greater than 3 characters