### PR TITLE
Open web links in browser

### DIFF
--- a/Core/Command.cs
+++ b/Core/Command.cs
@@ -2891,6 +2891,7 @@ namespace GenieClient.Genie
             EchoText("checkforupdates=" + oGlobals.Config.CheckForUpdates.ToString() + System.Environment.NewLine);
             EchoText("autoupdate=" + oGlobals.Config.AutoUpdate.ToString() + System.Environment.NewLine);
             EchoText("automapperalpha=" + oGlobals.Config.AutoMapperAlpha.ToString() + System.Environment.NewLine);
+            EchoText("weblinksafety=" + oGlobals.Config.bWebLinkSafety.ToString() + System.Environment.NewLine);
         }
 
         private void ListColors()

--- a/Forms/FormMain.cs
+++ b/Forms/FormMain.cs
@@ -7901,6 +7901,14 @@ namespace GenieClient
                 TextBoxInput_SendText(m_oGlobals.ParseGlobalVars(sLink));
                 TextBoxInput.Focus();
             }
+            if (link.StartsWith("http://") || link.StartsWith("https://"))
+            {
+                if (m_oGlobals.Config.bWebLinkSafety)
+                {
+                    link = "https://www.play.net/bounce/redirect.asp?URL=" + link;
+                }
+                Utility.OpenBrowser(link);
+            }
         }
 
         private void FormMain_SizeChange(object sender, EventArgs e)

--- a/Lists/Config.cs
+++ b/Lists/Config.cs
@@ -48,6 +48,7 @@ namespace GenieClient.Genie
         public string sConfigDirProfile = "Config";
         public bool bShowLinks = false;
         public string sLogDir = "Logs";
+        public bool bWebLinkSafety = true;
 
         public bool PromptBreak { get; set; } = true;
         public bool PromptForce { get; set; } = true;
@@ -401,6 +402,7 @@ namespace GenieClient.Genie
                 oStreamWriter.WriteLine("#config {usertimeout} {" + iUserActivityTimeout + "}");
                 oStreamWriter.WriteLine("#config {usertimeoutcommand} {" + sUserActivityCommand + "}");
                 oStreamWriter.WriteLine("#config {showlinks} {" + bShowLinks + "}");
+                oStreamWriter.WriteLine("#config {weblinksafety} {" + bWebLinkSafety + "}");
                 oStreamWriter.WriteLine($"#config {{rubypath}} {{{RubyPath}}}");
                 oStreamWriter.WriteLine($"#config {{cmdpath}} {{{CmdPath}}}");
                 oStreamWriter.WriteLine($"#config {{lichpath}} {{{LichPath}}}");
@@ -1151,6 +1153,30 @@ namespace GenieClient.Genie
 
                                 break;
                             }
+
+                        case "weblinksafety":
+                            {
+                                var switchExpr13 = sValue.ToLower();
+                                switch (switchExpr13)
+                                {
+                                    case "on":
+                                    case "true":
+                                    case "1":
+                                        {
+                                            bWebLinkSafety = true;
+                                            break;
+                                        }
+
+                                    default:
+                                        {
+                                            bWebLinkSafety = false;
+                                            break;
+                                        }
+                                }
+
+                                break;
+                            }
+
                         default:
                             throw new Exception($"Config {switchExpr} was not recognized.");
                     }


### PR DESCRIPTION
Add the ability to open http:// and https:// links in the system's default web browser.

Also adds the "weblinksafety" config variable:
* When True, use the play.net link redirection warning page. (default)
* When False, open the link directly in the browser.

Resolves #99 