### PR TITLE
Change label text to "Value" on Variables config form

### DIFF
--- a/Forms/ConfigPanels/UCVariables.Designer.cs
+++ b/Forms/ConfigPanels/UCVariables.Designer.cs
@@ -207,7 +207,7 @@ namespace GenieClient
             _LabelAction.Name = "LabelAction";
             _LabelAction.Size = new Size(37, 13);
             _LabelAction.TabIndex = 10;
-            _LabelAction.Text = "Action";
+            _LabelAction.Text = "Value";
             // 
             // TextBoxVariable
             // 


### PR DESCRIPTION
Change the "Action" label text to "Value" on the Variables config form so that it is consistent with the column headings.

Resolves #49 