### PR TITLE
Scroll to top/bottom of text box with Ctrl+PageUp/Down

### DIFF
--- a/Forms/Components/ComponentTextBox.cs
+++ b/Forms/Components/ComponentTextBox.cs
@@ -25,6 +25,14 @@ namespace GenieClient
 
         public delegate void PageDownEventHandler();
 
+        public event CtrlPageUpEventHandler CtrlPageUp;
+
+        public delegate void CtrlPageUpEventHandler();
+
+        public event CtrlPageDownEventHandler CtrlPageDown;
+
+        public delegate void CtrlPageDownEventHandler();
+
         private Genie.Collections.ArrayList HistoryArray = new Genie.Collections.ArrayList();
         private int HistoryPos = -1;
         private int HistorySize = 20;
@@ -236,14 +244,28 @@ namespace GenieClient
 
                 case Keys.PageUp:
                     {
-                        PageUp?.Invoke();
+                        if (e.Control)
+                        {
+                            CtrlPageUp?.Invoke();
+                        }
+                        else
+                        {
+                            PageUp?.Invoke();
+                        }
                         e.Handled = true;
                         break;
                     }
 
                 case Keys.PageDown:
                     {
-                        PageDown?.Invoke();
+                        if (e.Control)
+                        {
+                            CtrlPageDown?.Invoke();
+                        }
+                        else
+                        {
+                            PageDown?.Invoke();
+                        }
                         e.Handled = true;
                         break;
                     }

--- a/Forms/FormMain.Designer.cs
+++ b/Forms/FormMain.Designer.cs
@@ -1327,6 +1327,8 @@ namespace GenieClient
             this._TextBoxInput.SendText += (this.TextBoxInput_SendText);
             this._TextBoxInput.PageUp += (this.TextBoxInput_PageUp);
             this._TextBoxInput.PageDown += (this.TextBoxInput_PageDown);
+            this._TextBoxInput.CtrlPageUp += new GenieClient.ComponentTextBox.CtrlPageUpEventHandler(this.TextBoxInput_CtrlPageUp);
+            this._TextBoxInput.CtrlPageDown += new GenieClient.ComponentTextBox.CtrlPageDownEventHandler(this.TextBoxInput_CtrlPageDown);
             this._TextBoxInput.KeyDown += (this.TextBoxInput_KeyDown);
             // 
             // _OpenFileDialogProfile

--- a/Forms/FormMain.cs
+++ b/Forms/FormMain.cs
@@ -6542,6 +6542,36 @@ namespace GenieClient
             bSendingKey = false;
         }
 
+        private void TextBoxInput_CtrlPageUp()
+        {
+            if (bSendingKey == true)
+                return;
+            bSendingKey = true;
+            if (!Information.IsNothing(oCurrentActiveForm))
+            {
+                oCurrentActiveForm.RichTextBoxOutput.Focus();
+                oCurrentActiveForm.RichTextBoxOutput.Select(0, 0);
+                TextBoxInput.Focus();
+            }
+
+            bSendingKey = false;
+        }
+
+        private void TextBoxInput_CtrlPageDown()
+        {
+            if (bSendingKey == true)
+                return;
+            bSendingKey = true;
+            if (!Information.IsNothing(oCurrentActiveForm))
+            {
+                oCurrentActiveForm.RichTextBoxOutput.Focus();
+                oCurrentActiveForm.RichTextBoxOutput.Select(oCurrentActiveForm.RichTextBoxOutput.Text.Length, 0);
+                TextBoxInput.Focus();
+            }
+
+            bSendingKey = false;
+        }
+
         private void ToolStripMenuItemSpecialPaste_Click(object sender, EventArgs e)
         {
             TextBoxInput.Focus();


### PR DESCRIPTION
Add ability to scroll to the top/bottom of a text box (like the Game window) with Ctrl+PageUp/Down.