### PR TITLE
[Mapper/MapForm.cs] Change encoding when saving maps from Unicode (UTF16LE) to UTF8.

### DIFF
--- a/Mapper/MapForm.cs
+++ b/Mapper/MapForm.cs
@@ -916,7 +916,7 @@ namespace GenieClient.Mapper
 
             try
             {
-                var xw = new XmlTextWriter(sPath, System.Text.Encoding.Unicode);
+                var xw = new XmlTextWriter(sPath, System.Text.Encoding.UTF8);
                 xw.Formatting = Formatting.Indented;
                 xw.WriteStartDocument();
                 xw.WriteStartElement("zone");


### PR DESCRIPTION
I believe this should close and resolve #166 