### PR TITLE
Add historysize and historyminlength config options

### DIFF
--- a/Core/Command.cs
+++ b/Core/Command.cs
@@ -2950,6 +2950,8 @@ namespace GenieClient.Genie
             EchoText("autoupdatelamp=" + oGlobals.Config.AutoUpdateLamp.ToString() + System.Environment.NewLine);
             EchoText("automapperalpha=" + oGlobals.Config.AutoMapperAlpha.ToString() + System.Environment.NewLine);
             EchoText("weblinksafety=" + oGlobals.Config.bWebLinkSafety.ToString() + System.Environment.NewLine);
+            EchoText("historysize=" + oGlobals.Config.iHistorySize.ToString() + System.Environment.NewLine);
+            EchoText("historyminlength=" + oGlobals.Config.iHistoryMinLength.ToString() + System.Environment.NewLine);
         }
 
         private void ListColors()

--- a/Forms/Components/ComponentTextBox.cs
+++ b/Forms/Components/ComponentTextBox.cs
@@ -36,7 +36,7 @@ namespace GenieClient
         private Genie.Collections.ArrayList HistoryArray = new Genie.Collections.ArrayList();
         private int HistoryPos = -1;
         private int HistorySize = 20;
-        private int HistoryMinLenght = 3;
+        private int HistoryMinLength = 3;
         private bool m_KeepInput = false;
 
         public bool KeepInput
@@ -59,14 +59,14 @@ namespace GenieClient
 
         public void SetHistoryMinLength(int size)
         {
-            HistoryMinLenght = size;
+            HistoryMinLength = size;
         }
 
         private void InsertHistory(string text)
         {
-            if (text.Length < HistoryMinLenght)
+            if (HistorySize == 0 || text.Length < HistoryMinLength)
             {
-                return; // Don't save short commands
+                return; // Don't save command
             }
 
             if (HistoryArray.Count > 0)

--- a/Forms/FormMain.cs
+++ b/Forms/FormMain.cs
@@ -7021,6 +7021,16 @@ namespace GenieClient
                         alwaysOnTopToolStripMenuItem.Checked = m_oGlobals.Config.AlwaysOnTop;
                         break;
                     }
+                case Genie.Config.ConfigFieldUpdated.HistorySize:
+                    {
+                        TextBoxInput.SetHistorySize(m_oGlobals.Config.iHistorySize);
+                        break;
+                    }
+                case Genie.Config.ConfigFieldUpdated.HistoryMinLength:
+                    {
+                        TextBoxInput.SetHistoryMinLength(m_oGlobals.Config.iHistoryMinLength);
+                        break;
+                    }
             }
         }
 

--- a/Lists/Config.cs
+++ b/Lists/Config.cs
@@ -53,6 +53,8 @@ namespace GenieClient.Genie
         public string sLogDir = "Logs";
         public string sArtDir = "Art";
         public bool bWebLinkSafety = true;
+        public int iHistorySize = 20;
+        public int iHistoryMinLength = 3;
 
         public bool SizeInputToGame { get; set; } = false;
         public bool UpdateMapperScripts { get; set; } = false;
@@ -403,7 +405,9 @@ namespace GenieClient.Genie
             ImagesEnabled,
             SizeInputToGame,
             AlwaysOnTop,
-            UpdateMapperScripts
+            UpdateMapperScripts,
+            HistorySize,
+            HistoryMinLength
         }
 
         public Font MonoFont
@@ -498,6 +502,9 @@ namespace GenieClient.Genie
                 oStreamWriter.WriteLine("#config {showlinks} {" + bShowLinks + "}");
                 oStreamWriter.WriteLine("#config {showimages} {" + bShowImages + "}");
                 oStreamWriter.WriteLine("#config {weblinksafety} {" + bWebLinkSafety + "}");
+                oStreamWriter.WriteLine("#config {historysize} {" + iHistorySize + "}");
+                oStreamWriter.WriteLine("#config {historyminlength} {" + iHistoryMinLength + "}");
+
                 oStreamWriter.WriteLine($"#config {{rubypath}} {{{RubyPath}}}");
                 oStreamWriter.WriteLine($"#config {{cmdpath}} {{{CmdPath}}}");
                 oStreamWriter.WriteLine($"#config {{lichpath}} {{{LichPath}}}");
@@ -1435,6 +1442,26 @@ namespace GenieClient.Genie
                                         }
                                 }
 
+                                break;
+                            }
+
+                        case "historysize":
+                            {
+                                if (sValue.Length > 0)
+                                {
+                                    iHistorySize = Conversions.ToInteger(sValue);
+                                }
+                                ConfigChanged?.Invoke(ConfigFieldUpdated.HistorySize);
+                                break;
+                            }
+
+                        case "historyminlength":
+                            {
+                                if (sValue.Length > 0)
+                                {
+                                    iHistoryMinLength = Conversions.ToInteger(sValue);
+                                }
+                                ConfigChanged?.Invoke(ConfigFieldUpdated.HistoryMinLength);
                                 break;
                             }
 


### PR DESCRIPTION
Add new config options:
* historysize: Specifies the maximum number of commands that are stored in the input box history. (Default value; 20)
* historyminlength: Defines the minimum length a command must have to be saved in the input history. (Default value: 3)

Additional notes:
* Input box history can now be disabled entirely by setting historysize to 0.
* The defaults provided were sourced from the existing hardcoded values for these variables.