### PR TITLE
Strip DR showroomid suffix from automapper input and game window

### DIFF
--- a/Core/Game.cs
+++ b/Core/Game.cs
@@ -533,6 +533,17 @@ namespace GenieClient.Genie
 
         private StringBuilder m_oXMLBuffer = new StringBuilder();
 
+        // Subtitle is "[Room Name]" with an optional " (123456)" suffix when DR's showroomid flag is on.
+        private static readonly Regex s_roomSubtitleRegex = new Regex(
+            @"^\[(?<name>.+?)\](?:\s*\((?<id>\d+)\))?\s*$",
+            RegexOptions.Compiled);
+
+        // Trailing " (123456)" that DR appends to the visible room name when showroomid is on.
+        // Lookahead anchor preserves the trailing newline that ends the styled line.
+        private static readonly Regex s_roomNameIdSuffixRegex = new Regex(
+            @"\s*\(\d+\)(?=\s*$)",
+            RegexOptions.Compiled);
+
         public void ParseGameRow(string sText)
         {
             var oXMLBuffer = new StringBuilder();
@@ -1399,18 +1410,30 @@ namespace GenieClient.Genie
                                 case "room":
                                     {
                                         string argstrAttributeName4 = "subtitle";
-                                        m_sRoomTitle = GetAttributeData(oXmlNode, argstrAttributeName4);
-                                        if (m_sRoomTitle.StartsWith(" - "))
+                                        var subtitle = GetAttributeData(oXmlNode, argstrAttributeName4);
+                                        if (subtitle.StartsWith(" - "))
                                         {
-                                            m_sRoomTitle = m_sRoomTitle.Substring(3);
+                                            subtitle = subtitle.Substring(3);
                                         }
 
-                                        if (m_sRoomTitle.StartsWith("["))
+                                        var roomMatch = s_roomSubtitleRegex.Match(subtitle);
+                                        string gameRoomId = "0";
+                                        if (roomMatch.Success)
                                         {
-                                            m_sRoomTitle = m_sRoomTitle.Substring(1, m_sRoomTitle.Length - 2);
+                                            m_sRoomTitle = roomMatch.Groups["name"].Value.Trim();
+                                            if (roomMatch.Groups["id"].Success)
+                                            {
+                                                gameRoomId = roomMatch.Groups["id"].Value;
+                                            }
+                                        }
+                                        else
+                                        {
+                                            m_sRoomTitle = subtitle.Trim();
                                         }
 
-                                        m_sRoomTitle = m_sRoomTitle.Trim();
+                                        m_oGlobals.VariableList.Add("gameroomid", gameRoomId, Globals.Variables.VariableType.Reserved);
+                                        VariableChanged("$gameroomid");
+
                                         string argkey = "roomname";
                                         m_oGlobals.VariableList.Add(argkey, m_sRoomTitle, Globals.Variables.VariableType.Reserved);
                                         string argsVariable1 = "$roomname";
@@ -2704,6 +2727,7 @@ namespace GenieClient.Genie
                                 color = m_oGlobals.PresetList["roomname"].FgColor;
                                 bgcolor = m_oGlobals.PresetList["roomname"].BgColor;
                                 m_oLastFgColor = color;
+                                sText = s_roomNameIdSuffixRegex.Replace(sText, "");
                                 break;
                             }
 

--- a/Lists/Globals.cs
+++ b/Lists/Globals.cs
@@ -841,6 +841,7 @@ namespace GenieClient.Genie
                 Add("roomplayers", "", VariableType.Reserved);
                 Add("roomexits", "", VariableType.Reserved);
                 Add("roomnote", "", VariableType.Reserved);
+                Add("gameroomid", "0", VariableType.Reserved);
 
                 Add("concentration", "100", VariableType.Reserved);
                 Add("encumbrance", "0", VariableType.Reserved);


### PR DESCRIPTION
## What
When DR's `flag showroomid on` is enabled, the appended ` (1234567)` suffix breaks AutoMapper (it can't match map XML against a mangled `$roomname`) and clutters the visible room name in the game window.

## Why
The previous `Substring(1, Length-2)` strip in `ParseGameRow`'s `case "room"` assumed the subtitle always ended with `]`. With `showroomid` on it ends with `)`, so `$roomname` came out as `Room Name] (1234567` — neither valid for AutoMapper matching nor pleasant to read.

## Changes
- `Game.ParseGameRow` case `"room"`: regex-parse the subtitle into a clean name plus optional ID; populate new reserved `$gameroomid`.
- `Game.PrintTextWithParse` case `"roomName"`: strip the trailing ` (1234567)` from the visible room name text (lookahead-anchored so the line-ending newline is preserved).
- `Globals.cs`: register `gameroomid` as a Reserved variable defaulting to `"0"` (matching the `$roomid` convention).

## How to test
1. Connect to DragonRealms with the AutoMapper enabled.
2. Run `flag showroomid on`; do `look` in a known mapped room.
3. Verify the room window shows `[Room Name]` on its own line (no trailing ID, room description on the next line).
4. Verify the map highlights the correct node.
5. Verify `#var $gameroomid` returns the DR room ID; `#var $roomname` returns the clean name; `#var $roomid` still returns the Genie internal node ID.
6. Run `flag showroomid off` and repeat — should behave identically to current `main`.

## Risk
- AutoMapper code path is untouched.
- `$roomname` value for `showroomid` off matches existing behavior byte-for-byte.
- Visible game window is unchanged when `showroomid` is off.