### PR TITLE
Fix Connect Using Profile AV, showroomid+critter room parsing, automapper loop-detection false positives, and automapper UI hang

### DIFF
--- a/Core/Game.cs
+++ b/Core/Game.cs
@@ -533,15 +533,28 @@ namespace GenieClient.Genie
 
         private StringBuilder m_oXMLBuffer = new StringBuilder();
 
-        // Subtitle is "[Room Name]" with an optional " (123456)" suffix when DR's showroomid flag is on.
+        // Extracts the room name from a "[Room Name]" subtitle. Stops at the first closing
+        // bracket so any trailing markers DR appends — room ID "(123456)", critter count
+        // "(**)", or anything else parenthesized — are excluded from the captured name.
+        // $roomname stays clean regardless of which markers are present, in any order.
         private static readonly Regex s_roomSubtitleRegex = new Regex(
-            @"^\[(?<name>.+?)\](?:\s*\((?<id>\d+)\))?\s*$",
+            @"^\[(?<name>[^\]]+)\]",
             RegexOptions.Compiled);
 
-        // Trailing " (123456)" that DR appends to the visible room name when showroomid is on.
-        // Lookahead anchor preserves the trailing newline that ends the styled line.
+        // Finds the numeric room ID anywhere in the subtitle (DR's showroomid output).
+        // Independent of name extraction so it works regardless of marker order:
+        // "[Name] (123) (**)" and "[Name] (**) (123)" both populate $gameroomid correctly.
+        private static readonly Regex s_subtitleIdRegex = new Regex(
+            @"\((?<id>\d+)\)",
+            RegexOptions.Compiled);
+
+        // Strips all trailing parenthesized markers from the visible room-name display:
+        // "(123456)" room IDs (from showroomid), "(**)" critter markers, and any other
+        // parenthesized annotations DR appends after the closing bracket. Critter
+        // detection uses the separate <room objs> stream ($monstercount/$monsterlist),
+        // so removing "(**)" from the title display does not affect anything programmatic.
         private static readonly Regex s_roomNameIdSuffixRegex = new Regex(
-            @"\s*\(\d+\)(?=\s*$)",
+            @"(?<=\])(\s*\([^)]*\))+",
             RegexOptions.Compiled);
 
         public void ParseGameRow(string sText)
@@ -1421,14 +1434,18 @@ namespace GenieClient.Genie
                                         if (roomMatch.Success)
                                         {
                                             m_sRoomTitle = roomMatch.Groups["name"].Value.Trim();
-                                            if (roomMatch.Groups["id"].Success)
-                                            {
-                                                gameRoomId = roomMatch.Groups["id"].Value;
-                                            }
                                         }
                                         else
                                         {
                                             m_sRoomTitle = subtitle.Trim();
+                                        }
+
+                                        // Search the whole subtitle for the numeric room ID, regardless of
+                                        // where DR placed it relative to other markers like "(**)".
+                                        var idMatch = s_subtitleIdRegex.Match(subtitle);
+                                        if (idMatch.Success)
+                                        {
+                                            gameRoomId = idMatch.Groups["id"].Value;
                                         }
 
                                         m_oGlobals.VariableList.Add("gameroomid", gameRoomId, Globals.Variables.VariableType.Reserved);

--- a/Forms/Components/ComponentRichTextBox.cs
+++ b/Forms/Components/ComponentRichTextBox.cs
@@ -1020,17 +1020,31 @@ namespace GenieClient
 
         }
 
+        private bool m_bInSetScrollBars;
+
         public void SetScrollBars()
         {
-            if (!IsHandleCreated) return;
-            if (Win32Utility.GetFirstLineVisible(Handle) > 0)
+            // Re-entry guard: setting ScrollBars below triggers RecreateHandle, whose destroy phase
+            // fires FormSkin_Resize, which re-enters this method. Without the guard, the inner call
+            // ran with a transient/zero handle and the recreation completed with ScrollBars desynced
+            // from native style bits — AVs on the next EM_STREAMIN from the socket BG thread.
+            if (m_bInSetScrollBars) return;
+            m_bInSetScrollBars = true;
+            try
             {
-                ScrollBars = RichTextBoxScrollBars.ForcedVertical;
+                if (Win32Utility.GetFirstLineVisible(Handle) > 0)
+                {
+                    ScrollBars = RichTextBoxScrollBars.ForcedVertical;
+                }
+                else
+                {
+                    ScrollBars = RichTextBoxScrollBars.None;
+                    VScroll += VScrollEvent;
+                }
             }
-            else
+            finally
             {
-                ScrollBars = RichTextBoxScrollBars.None;
-                VScroll += VScrollEvent;
+                m_bInSetScrollBars = false;
             }
         }
     }

--- a/Forms/FormMain.cs
+++ b/Forms/FormMain.cs
@@ -4917,7 +4917,14 @@ namespace GenieClient
 
             if (InvokeRequired)
             {
-                Invoke((Action)(() => AddText(sText, oColor, oBgColor, oTargetWindow, sTargetWindow, bNoCache, bMono, bPrompt, bInput)));
+                // BeginInvoke (not Invoke) is required here: BG threads (notably the socket
+                // ReceiveCallback) can be holding Script.m_oThreadLock when they call AddText
+                // via the trigger -> action -> put -> SendText -> echo chain. A synchronous
+                // Invoke would block them while the UI thread is itself trying to acquire that
+                // same lock from DrainPendingVariableChanges -> Script.TriggerVariableChanged,
+                // producing a deadlock that resolves only when Monitor.TryEnter times out
+                // (3.5s per blocked variable change — visible to the user as a 5-10s UI hang).
+                BeginInvoke((Action)(() => AddText(sText, oColor, oBgColor, oTargetWindow, sTargetWindow, bNoCache, bMono, bPrompt, bInput)));
                 return;
             }
 

--- a/Script/Script.cs
+++ b/Script/Script.cs
@@ -692,8 +692,8 @@ namespace GenieClient
 
         // Cross-wait infinite loop detection: track recent game sends by text + timestamp
         private readonly Queue<(string text, DateTime when)> m_oSendHistory = new Queue<(string, DateTime)>();
-        private const int LOOP_SAME_CMD_LIMIT = 10;   // same text N times in window
-        private const int LOOP_TOTAL_CMD_LIMIT = 30;  // any N total sends in window
+        private const int LOOP_SAME_CMD_LIMIT = 100;  // same text N times in window
+        private const int LOOP_TOTAL_CMD_LIMIT = 100; // any N total sends in window
         private const double LOOP_WINDOW_SECONDS = 10.0;
 
         // Allocating and unallocating is slow.


### PR DESCRIPTION
## Summary

Four independent fixes in the connection / script / movement path on 4.5.0.3:

- **ComponentRichTextBox.SetScrollBars** — AV (AccessViolationException) crash during Connect Using Profile when the loaded layout differs from the current one. The 4.5.0.0 `if (!IsHandleCreated) return;` short-circuit caused a re-entrant call (during the `ScrollBars =` setter's `RecreateHandle`) to skip while the outer call's state was still mid-transition, desyncing `ScrollBars` from the native window style bits. Replaced with an explicit re-entrancy guard.

- **Game.cs room subtitle parsing** — `$roomname` was set to the raw bracketed string (including `(123456)` and `(**)` markers) when DR's `showroomid` was on AND critters were in the room, because the 4.5.0.2 regex required the line to end after `(id)`. Generalized to ignore any trailing parenthesized markers; `$gameroomid` is populated via a separate search so marker order does not matter. Visible-text ID strip extended to handle markers after the closing `]`.

- **Script.cs loop-detection limits** — `LOOP_SAME_CMD_LIMIT` and `LOOP_TOTAL_CMD_LIMIT` raised from 10/30 to 100/100. Standard `automapper.cmd` walks routinely involve 10+ same-direction moves on long roads, which previously tripped the 4.5.0.0 detector mid-walk. Verified clean automapper runs across multiple cities at the new limit.

- **FormMain.AddText — BeginInvoke from BG threads** — Fixes the intermittent 5-10s UI freeze during automapper runs. Root cause: deadlock between the socket BG thread (held `Script.m_oThreadLock` while waiting on a synchronous `Invoke` to dispatch a trigger-action echo) and the UI thread (waiting for that same lock from `DrainPendingVariableChanges → Script.TriggerVariableChanged`). Confirmed via the Threads window: BG thread parked in `Control.WaitForWaitHandle`, UI thread parked in `Monitor.TryEnter`. Switching to `BeginInvoke` lets the BG thread release the lock immediately. Verified the hang no longer reproduces.

## Test plan

- [ ] Connect Using Profile with a profile whose saved layout differs from the current layout — no AV
- [ ] Connect with DR's \`showroomid\` toggled on, walk into a room containing critters — \`\$roomname\` is the clean room name, \`\$gameroomid\` is the numeric ID, visible display shows the bracketed name without the ID suffix
- [ ] Run \`.automapper\` over a route with 10+ same-direction segments (any long road) — script completes without \`possible infinite loop detected\` abort
- [ ] Run \`.automapper\` over a multi-city route — no UI hang during the walk